### PR TITLE
Implementation of the SINE matching model

### DIFF
--- a/examples/matching/run_ml_sine.py
+++ b/examples/matching/run_ml_sine.py
@@ -1,0 +1,122 @@
+import sys
+
+sys.path.append("../..")
+
+import os
+import numpy as np
+import pandas as pd
+import torch
+
+from sklearn.preprocessing import MinMaxScaler, LabelEncoder
+from torch_rechub.models.matching import SINE
+from torch_rechub.trainers import MatchTrainer
+from torch_rechub.utils.match import generate_seq_feature_match, gen_model_input
+from torch_rechub.utils.data import df_to_dict, MatchDataGenerator
+from movielens_utils import match_evaluation
+
+
+def get_movielens_data(data_path, load_cache=False, seq_max_len=50):
+    data = pd.read_csv(data_path)
+    data["cate_id"] = data["genres"].apply(lambda x: x.split("|")[0])
+    sparse_features = ['user_id', 'movie_id']
+    user_col, item_col = "user_id", "movie_id"
+
+    feature_max_idx = {}
+    for feature in sparse_features:
+        lbe = LabelEncoder()
+        data[feature] = lbe.fit_transform(data[feature]) + 1
+        feature_max_idx[feature] = data[feature].max() + 1
+        if feature == user_col:
+            user_map = {encode_id + 1: raw_id for encode_id, raw_id in enumerate(lbe.classes_)}  #encode user id: raw user id
+        if feature == item_col:
+            item_map = {encode_id + 1: raw_id for encode_id, raw_id in enumerate(lbe.classes_)}  #encode item id: raw item id
+    np.save("./data/ml-1m/saved/raw_id_maps.npy", np.array((user_map, item_map), dtype=object))
+
+    user_profile = data[["user_id"]].drop_duplicates('user_id')
+    item_profile = data[["movie_id"]].drop_duplicates('movie_id')
+
+    if load_cache:  #if you have run this script before and saved the preprocessed data
+        x_train, y_train, x_test = np.load("./data/ml-1m/saved/data_cache.npy", allow_pickle=True)
+    else:
+        #Note: mode=2 means list-wise negative sample generate, saved in last col "neg_items"
+        df_train, df_test = generate_seq_feature_match(data,
+                                                       user_col,
+                                                       item_col,
+                                                       time_col="timestamp",
+                                                       item_attribute_cols=[],
+                                                       sample_method=1,
+                                                       mode=2,
+                                                       neg_ratio=3,
+                                                       min_item=0)
+        x_train = gen_model_input(df_train, user_profile, user_col, item_profile, item_col, seq_max_len=seq_max_len, padding='post', truncating='post')
+        y_train = np.array([0] * df_train.shape[0])  #label=0 means the first pred value is positive sample
+        x_test = gen_model_input(df_test, user_profile, user_col, item_profile, item_col, seq_max_len=seq_max_len, padding='post', truncating='post')
+        np.save("./data/ml-1m/saved/data_cache.npy", np.array((x_train, y_train, x_test), dtype=object))
+
+    user_features, item_features, history_features, neg_item_features = ["user_id"], ["movie_id"], ["hist_movie_id"], ["neg_items"]
+    num_users, num_items = feature_max_idx['user_id'], feature_max_idx['movie_id']
+
+    all_item = df_to_dict(item_profile)
+    test_user = x_test
+    return user_features, history_features, item_features, neg_item_features, num_users, num_items, x_train, y_train, all_item, test_user
+
+
+
+def main(dataset_path, model_name, epoch, learning_rate, batch_size, weight_decay, device, save_dir, seed, embedding_dim, hidden_dim, num_concept, num_intention, temperature, seq_max_len):
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+    torch.manual_seed(seed)
+    _, history_features, item_features, neg_item_features, _, num_items, x_train, y_train, all_item, test_user = get_movielens_data(dataset_path, seq_max_len=seq_max_len)
+    dg = MatchDataGenerator(x=x_train, y=y_train)
+                    
+    model = SINE(history_features, item_features, neg_item_features, num_items, embedding_dim, hidden_dim, num_concept, num_intention, seq_max_len, temperature=temperature)
+
+    #mode=1 means pair-wise learning
+    trainer = MatchTrainer(model,
+                           mode=2,
+                           optimizer_params={
+                               "lr": learning_rate,
+                               "weight_decay": weight_decay
+                           },
+                           n_epoch=epoch,
+                           device=device,
+                           model_path=save_dir,
+                           gpus=[0])
+
+    train_dl, test_dl, item_dl = dg.generate_dataloader(test_user, all_item, batch_size=batch_size, num_workers=6)
+    trainer.fit(train_dl)
+
+    print("inference embedding")
+    user_embedding = trainer.inference_embedding(model=model, mode="user", data_loader=test_dl, model_path=save_dir)
+    item_embedding = trainer.inference_embedding(model=model, mode="item", data_loader=item_dl, model_path=save_dir)
+    print(user_embedding.shape, item_embedding.shape)
+    match_evaluation(user_embedding, item_embedding, test_user, all_item, topk=10)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset_path', default="./data/ml-1m/ml-1m_sample.csv")
+    parser.add_argument('--model_name', default='sine')
+    parser.add_argument('--epoch', type=int, default=3)
+    parser.add_argument('--learning_rate', type=float, default=1e-4)
+    parser.add_argument('--batch_size', type=int, default=256)
+    parser.add_argument('--weight_decay', type=float, default=1e-4)
+    parser.add_argument('--device', default='cuda:0')
+    parser.add_argument('--save_dir', default='./data/ml-1m/saved/')
+    parser.add_argument('--seed', type=int, default=2022)    
+    
+    parser.add_argument('--embedding_dim', type=int, default=128)
+    parser.add_argument('--hidden_dim', type=int, default=512)
+    parser.add_argument('--num_concept', type=int, default=50)
+    parser.add_argument('--num_intention', type=int, default=4)
+    parser.add_argument('--temperature', type=int, default=0.1)
+    parser.add_argument('--seq_max_len', type=int, default=20)
+
+    args = parser.parse_args()
+    main(args.dataset_path, args.model_name, args.epoch, args.learning_rate, args.batch_size, args.weight_decay, args.device,
+         args.save_dir, args.seed, args.embedding_dim, args.hidden_dim, args.num_concept, args.num_intention, 
+         args.temperature, args.seq_max_len)
+"""
+python run_ml_sine.py
+"""

--- a/torch_rechub/models/matching/__init__.py
+++ b/torch_rechub/models/matching/__init__.py
@@ -6,3 +6,4 @@ from .gru4rec import GRU4Rec
 from .comirec import ComirecSA, ComirecDR
 from .mind import MIND
 from .sasrec import SASRec
+from .sine import SINE

--- a/torch_rechub/models/matching/sine.py
+++ b/torch_rechub/models/matching/sine.py
@@ -1,0 +1,151 @@
+"""
+Date: created on 03/07/2022
+References:
+    paper: Sparse-Interest Network for Sequential Recommendation
+    url: https://arxiv.org/abs/2102.09267
+    code: https://github.com/Qiaoyut/SINE/blob/master/model.py
+Authors: Bo Kang, klinux@live.com
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import einsum
+
+class SINE(torch.nn.Module):
+    """The match model was proposed in `Sparse-Interest Network for Sequential Recommendation` paper.
+
+    Args:        
+        history_features (list[str]): training history feature names, this is for indexing the historical sequences from input dictionary
+        item_features (list[str]): item feature names, this is for indexing the items from input dictionary
+        neg_item_features (list[str]): neg item feature names, this for indexing negative items from input dictionary
+        num_items (int): number of items in the data
+        embedding_dim (int): dimensionality of the embeddings        
+        hidden_dim (int): dimensionality of the hidden layer in self attention modules
+        num_concept (int): number of concept, also called conceptual prototypes 
+        num_intention (int): number of (user) specific intentions out of the concepts
+        seq_max_len (int): max sequence length of input item sequence
+        num_heads （int): number of attention heads in self attention modules, default to 1
+        temperature (float): temperature factor in the similarity measure, default to 1.0        
+    """
+    def __init__(self, history_features, item_features, neg_item_features, num_items, embedding_dim, hidden_dim, num_concept, num_intention, seq_max_len, num_heads=1, temperature=1.0):
+        super().__init__()        
+        self.item_features = item_features
+        self.history_features = history_features
+        self.neg_item_features = neg_item_features
+        self.temperature = temperature
+        self.num_concept = num_concept        
+        self.num_intention = num_intention
+        self.seq_max_len = seq_max_len
+
+        std = 1e-4
+        self.item_embedding = torch.nn.Embedding(num_items, embedding_dim)
+        torch.nn.init.normal_(self.item_embedding.weight, 0, std)
+        self.concept_embedding = torch.nn.Embedding(num_concept, embedding_dim)
+        torch.nn.init.normal_(self.concept_embedding.weight, 0, std)
+        self.position_embedding = torch.nn.Embedding(seq_max_len, embedding_dim)
+        torch.nn.init.normal_(self.position_embedding.weight, 0, std)
+    
+
+        self.W_1 = torch.nn.Parameter(torch.rand(embedding_dim, hidden_dim), requires_grad=True)        
+        self.W_2 = torch.nn.Parameter(torch.rand(hidden_dim, num_heads), requires_grad=True)
+
+        self.W_3 = torch.nn.Parameter(torch.rand(embedding_dim, embedding_dim), requires_grad=True)
+
+        self.W_k1 = torch.nn.Parameter(torch.rand(embedding_dim, hidden_dim), requires_grad=True)
+        self.W_k2 = torch.nn.Parameter(torch.rand(hidden_dim, num_intention), requires_grad=True)
+
+        self.W_4 = torch.nn.Parameter(torch.rand(embedding_dim, hidden_dim), requires_grad=True)
+        self.W_5 = torch.nn.Parameter(torch.rand(hidden_dim, num_heads), requires_grad=True)
+
+        self.mode = None
+
+    def forward(self, x):
+        user_embedding = self.user_tower(x)
+        item_embedding = self.item_tower(x)
+        if self.mode == "user":
+            return user_embedding
+        if self.mode == "item":
+            return item_embedding
+        
+        y = torch.mul(user_embedding, item_embedding).sum(dim=1)
+
+        # # compute covariance regularizer
+        # M = torch.cov(self.concept_embedding.weight, correction=0)
+        # l_c = (torch.norm(M, p='fro')**2 - torch.norm(torch.diag(M), p='fro')**2)/2
+
+        return y
+
+    def user_tower(self, x):
+        if self.mode == "item":
+            return None
+        
+        # sparse interests extraction
+        ## user specific historical item embedding X^u
+        hist_item = x[self.history_features[0]]
+        X_u = self.item_embedding(hist_item) + self.position_embedding.weight.unsqueeze(0)
+        X_u_mask = (x[self.history_features[0]] > 0).long()
+
+        ## user specific conceptual prototypes C^u
+        ### attention a
+        H_1 = einsum('bse, ed -> bsd', X_u, self.W_1).tanh()
+        a_hist = F.softmax(einsum('bsd, dh -> bsh', H_1, self.W_2) + -1.e9 * (1 - X_u_mask.unsqueeze(-1).float()), dim=1) 
+
+        ### virtual concept vector z_u
+        z_u = einsum("bse, bsh -> be", X_u, a_hist)
+
+        ### similarity between user's concept vector and entire conceptual prototypes s^u
+        s_u = einsum("be, te -> bt", z_u, self.concept_embedding.weight)
+        s_u_top_k = torch.topk(s_u, self.num_intention)
+
+        ### final C^u
+        C_u =  einsum("bk, bke -> bke", torch.sigmoid(s_u_top_k.values), self.concept_embedding(s_u_top_k.indices))
+
+        ## user intention assignment P_{k|t}        
+        P_u = F.softmax(einsum("bse, bke -> bks", F.normalize(X_u @ self.W_3, dim=-1),  F.normalize(C_u, p=2, dim=-1)), dim=1)
+
+        ## attention weighing P_{t|k}
+        H_2 = einsum('bse, ed -> bsd', X_u, self.W_k1).tanh()
+        a_concept_k = F.softmax(einsum('bsd, dk -> bsk', H_2, self.W_k2) + -1.e9 * (1 - X_u_mask.unsqueeze(-1).float()), dim=1) 
+
+        ## multiple interests encoding \phi_\theta^k(x^u)
+        phi_u = einsum("bks, bse -> bke", P_u * a_concept_k.permute(0, 2, 1), X_u)
+
+
+        # adaptive interest aggregation
+        ## intention aware input behavior \hat{X^u}
+        X_u_hat = einsum('bks, bke -> bse', P_u, C_u)
+
+        ## user's next intention C^u_{apt}
+        H_3 = einsum('bse, ed -> bsd', X_u_hat, self.W_4).tanh()
+        C_u_apt = F.normalize(
+                    einsum(
+                        "bs, bse -> be",
+                        F.softmax(einsum('bsd, dh -> bsh', H_3, self.W_5).reshape(-1, self.seq_max_len) + -1.e9 * (1 - X_u_mask.float()), dim=1),
+                        X_u_hat
+                    ), -1)
+
+        ## aggregation weights e_k^u
+        e_u = F.softmax(einsum('be, bke -> bk', C_u_apt, phi_u) / self.temperature, dim=1)         
+
+
+        # final user representation v^u
+        v_u = einsum('bk, bke -> be', e_u, phi_u)
+
+        if self.mode == "user":
+            return v_u
+        return v_u.unsqueeze(1)
+
+    def item_tower(self, x):
+        if self.mode == "user":
+            return None
+        pos_embedding = self.item_embedding(x[self.item_features[0]]).unsqueeze(1)
+        if self.mode == "item":  #inference embedding mode
+            return pos_embedding.squeeze(1)  #[batch_size, embed_dim]
+        neg_embeddings = self.item_embedding(x[self.neg_item_features[0]]).squeeze(1)  #[batch_size, n_neg_items, embed_dim]        
+
+        return torch.cat((pos_embedding, neg_embeddings), dim=1)  #[batch_size, 1+n_neg_items, embed_dim]
+
+    def gen_mask(self, x):
+        his_list = x[self.history_features[0].name]
+        mask = (his_list > 0).long()
+        return mask


### PR DESCRIPTION
This is an implementation of SINE (Sparse-Interest Network for Sequential Recommendation) matching model. The implementation follows the arXiv paper (https://arxiv.org/abs/2102.09267), but also take into consider the original implementation in TensorFlow (https://github.com/Qiaoyut/SINE/blob/master/model.py). However, the original implementation seems to significantly deviate (e.g., position embedding, implementation of self attention, usage of temperature parameter, etc) from what the model is described in the SINE paper, I decided to first follow the original paper as much as possible. 

### Metrics averaged over 5 rounds on ml-1m 
(with the config in run_ml_sine.py file, with @k parameter and data file changed to 100 and ml-1m.csv)
* Hit/Recall@100: 0.12134 (± 0.019)
* Precision@100: 0.0012 (± 0.0002), Recall@100

### Next steps
* follow the exact computation of the TensorFlow implementation via debugger is possible. 
* current framework architecture does not allow the model to pass a model-based regularizer (in this case a covariance regularizer) and add in to the total loss function, this could be useful in the future. 
* the metrics on ml-1m in the original paper could not be reproduced for this implementation because the two implementations use different evaluation strategy. It would useful to borrow each other's evaluation strategy and to check the quality of the current implementation.
* the current implementation over fits quickly after e.g. 5 epochs, more knowledge about the hyper parameters and the regularization term could help in the future.
