### PR TITLE
Bug fix: the forward method from SINE model should return shape (batch_size, n_pos + n_neg)

### DIFF
--- a/examples/matching/run_ml_sine.py
+++ b/examples/matching/run_ml_sine.py
@@ -48,9 +48,9 @@ def get_movielens_data(data_path, load_cache=False, seq_max_len=50):
                                                        mode=2,
                                                        neg_ratio=3,
                                                        min_item=0)
-        x_train = gen_model_input(df_train, user_profile, user_col, item_profile, item_col, seq_max_len=seq_max_len, padding='post', truncating='post')
+        x_train = gen_model_input(df_train, user_profile, user_col, item_profile, item_col, seq_max_len=seq_max_len, padding='pre', truncating='pre')
         y_train = np.array([0] * df_train.shape[0])  #label=0 means the first pred value is positive sample
-        x_test = gen_model_input(df_test, user_profile, user_col, item_profile, item_col, seq_max_len=seq_max_len, padding='post', truncating='post')
+        x_test = gen_model_input(df_test, user_profile, user_col, item_profile, item_col, seq_max_len=seq_max_len, padding='pre', truncating='pre')
         np.save("./data/ml-1m/saved/data_cache.npy", np.array((x_train, y_train, x_test), dtype=object))
 
     user_features, item_features, history_features, neg_item_features = ["user_id"], ["movie_id"], ["hist_movie_id"], ["neg_items"]
@@ -98,20 +98,20 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--dataset_path', default="./data/ml-1m/ml-1m_sample.csv")
     parser.add_argument('--model_name', default='sine')
-    parser.add_argument('--epoch', type=int, default=3)
-    parser.add_argument('--learning_rate', type=float, default=1e-4)
+    parser.add_argument('--epoch', type=int, default=10)
+    parser.add_argument('--learning_rate', type=float, default=1e-3)
     parser.add_argument('--batch_size', type=int, default=256)
-    parser.add_argument('--weight_decay', type=float, default=1e-4)
+    parser.add_argument('--weight_decay', type=float, default=1e-6)
     parser.add_argument('--device', default='cuda:0')
     parser.add_argument('--save_dir', default='./data/ml-1m/saved/')
     parser.add_argument('--seed', type=int, default=2022)    
     
     parser.add_argument('--embedding_dim', type=int, default=128)
     parser.add_argument('--hidden_dim', type=int, default=512)
-    parser.add_argument('--num_concept', type=int, default=50)
-    parser.add_argument('--num_intention', type=int, default=4)
+    parser.add_argument('--num_concept', type=int, default=10)
+    parser.add_argument('--num_intention', type=int, default=2)
     parser.add_argument('--temperature', type=int, default=0.1)
-    parser.add_argument('--seq_max_len', type=int, default=20)
+    parser.add_argument('--seq_max_len', type=int, default=50)
 
     args = parser.parse_args()
     main(args.dataset_path, args.model_name, args.epoch, args.learning_rate, args.batch_size, args.weight_decay, args.device,

--- a/torch_rechub/models/matching/sine.py
+++ b/torch_rechub/models/matching/sine.py
@@ -67,7 +67,7 @@ class SINE(torch.nn.Module):
         if self.mode == "item":
             return item_embedding
         
-        y = torch.mul(user_embedding, item_embedding).sum(dim=1)
+        y = torch.mul(user_embedding, item_embedding).sum(dim=-1)
 
         # # compute covariance regularizer
         # M = torch.cov(self.concept_embedding.weight, correction=0)


### PR DESCRIPTION
Three changes are made in this commit: 
1. SINE model forward function. The returned value of the forward function in SINE model used to sum over dim=1, see [this line](https://github.com/datawhalechina/torch-rechub/blob/64b1c7c47a67effe9ca824dc8e825666bc18d7b5/torch_rechub/models/matching/sine.py#L70), returning a tensor with shape (batch_size, embedding_dim). However, this is incorrect, it should be sum along the embedding dimension in order to yield a tensor with shape (batch_size, n_pos+n_neg). This is fixed in this commit.
2. train/test user historical sequence generating scheme. The padding and truncating on are changed to "pre", yielding a more appropriate historical sequence.
3. Update default hyperparameters to the ones used in the original SINE implementation. Before fixing the forward function bug (point 1), the training was not stable and model can easily get overfitted. With strong regularization hyperparamter on Movielens 1M benchmark gives test scores:
{'NDCG': ['NDCG@100: 0.0012'], 'MRR': ['MRR@100: 0.0064'], 'Recall': ['Recall@100: 0.1121'], 'Hit': ['Hit@100: 0.1121'], 'Precision': ['Precision@100: 0.0011']}

After, the bug was fixed, the training behavior is stabilized, thus the hyperparameters are adjust to allow more epochs, larger learning rate, and less regularization. Movielens 1m test scores are now:
{'NDCG': ['NDCG@100: 0.0022'], 'MRR': ['MRR@100: 0.0137'], 'Recall': ['Recall@100: 0.2026'], 'Hit': ['Hit@100: 0.2026'], 'Precision': ['Precision@100: 0.002']}

After changing the historical sequence generating scheme from "post" to "pre", the test scores are further improved:
{'NDCG': ['NDCG@100: 0.0052'], 'MRR': ['MRR@100: 0.0382'], 'Recall': ['Recall@100: 0.4298'], 'Hit': ['Hit@100: 0.4298'], 'Precision': ['Precision@100: 0.0043']}


