### PR TITLE
Implementation of FFM module, (FAT-)DeepFFM model.

### DIFF
--- a/examples/ranking/run_criteo.py
+++ b/examples/ranking/run_criteo.py
@@ -5,7 +5,7 @@ sys.path.append("../..")
 import numpy as np
 import pandas as pd
 import torch
-from torch_rechub.models.ranking import WideDeep, DeepFM, DCN
+from torch_rechub.models.ranking import WideDeep, DeepFM, DCN, DeepFFM, FatDeepFFM
 from torch_rechub.trainers import CTRTrainer
 from torch_rechub.basic.features import DenseFeature, SparseFeature
 from torch_rechub.utils.data import DataGenerator
@@ -46,15 +46,17 @@ def get_criteo_data_dict(data_path):
 
     dense_feas = [DenseFeature(feature_name) for feature_name in dense_features]
     sparse_feas = [SparseFeature(feature_name, vocab_size=data[feature_name].nunique(), embed_dim=16) for feature_name in sparse_features]
+    ffm_linear_feas = [SparseFeature(feature.name, vocab_size=feature.vocab_size, embed_dim=1) for feature in sparse_feas]
+    ffm_cross_feas = [SparseFeature(feature.name, vocab_size=feature.vocab_size*len(sparse_feas), embed_dim=10) for feature in sparse_feas]
     y = data["label"]
     del data["label"]
     x = data
-    return dense_feas, sparse_feas, x, y
+    return dense_feas, sparse_feas, ffm_linear_feas, ffm_cross_feas, x, y
 
 
 def main(dataset_path, model_name, epoch, learning_rate, batch_size, weight_decay, device, save_dir, seed):
     torch.manual_seed(seed)
-    dense_feas, sparse_feas, x, y = get_criteo_data_dict(dataset_path)
+    dense_feas, sparse_feas, ffm_linear_feas, ffm_cross_feas, x, y = get_criteo_data_dict(dataset_path)
     dg = DataGenerator(x, y)
     train_dataloader, val_dataloader, test_dataloader = dg.generate_dataloader(split_ratio=[0.7, 0.1], batch_size=batch_size)
     if model_name == "widedeep":
@@ -63,6 +65,10 @@ def main(dataset_path, model_name, epoch, learning_rate, batch_size, weight_deca
         model = DeepFM(deep_features=dense_feas, fm_features=sparse_feas, mlp_params={"dims": [256, 128], "dropout": 0.2, "activation": "relu"})
     elif model_name == "dcn":
         model = DCN(features=dense_feas + sparse_feas, n_cross_layers=3, mlp_params={"dims": [256, 128]})
+    elif model_name == "deepffm":        
+        model = DeepFFM(linear_features=ffm_linear_feas, cross_features=ffm_cross_feas, embed_dim=10, mlp_params={"dims": [1600, 1600], "dropout": 0.5, "activation": "relu"})
+    elif model_name == "fat_deepffm":
+        model = FatDeepFFM(linear_features=ffm_linear_feas, cross_features=ffm_cross_feas, embed_dim=10, reduction_ratio=1, mlp_params={"dims": [1600, 1600], "dropout": 0.5, "activation": "relu"})
     ctr_trainer = CTRTrainer(model, optimizer_params={"lr": learning_rate, "weight_decay": weight_decay}, n_epoch=epoch, earlystop_patience=10, device=device, model_path=save_dir)
     #scheduler_fn=torch.optim.lr_scheduler.StepLR,scheduler_params={"step_size": 2,"gamma": 0.8},
     ctr_trainer.fit(train_dataloader, val_dataloader)
@@ -89,4 +95,6 @@ if __name__ == '__main__':
 python run_criteo.py --model_name widedeep
 python run_criteo.py --model_name deepfm
 python run_criteo.py --model_name dcn
+python run_criteo.py --model_name deepffm
+python run_criteo.py --model_name fat_deepffm
 """

--- a/torch_rechub/models/ranking/__init__.py
+++ b/torch_rechub/models/ranking/__init__.py
@@ -2,3 +2,4 @@ from .widedeep import WideDeep
 from .deepfm import DeepFM
 from .din import DIN
 from .dcn import DCN
+from .deepffm import DeepFFM, FatDeepFFM

--- a/torch_rechub/models/ranking/deepffm.py
+++ b/torch_rechub/models/ranking/deepffm.py
@@ -1,0 +1,123 @@
+"""
+Date: created on 31/07/2022
+References: 
+    paper: FAT-DeepFFM: Field Attentive Deep Field-aware Factorization Machine
+    url: https://arxiv.org/abs/1905.06336    
+Authors: Bo Kang, klinux@live.com
+"""
+
+import torch
+import torch.nn as nn
+
+from ...basic.layers import CEN, EmbeddingLayer, FFM, MLP
+
+
+class DeepFFM(nn.Module):
+    """The DeepFFM model, mentioned on the `webpage 
+    <https://cs.nju.edu.cn/31/60/c1654a209248/page.htm>` which is the first 
+    work that introduces FFM model into neural CTR system. It is also described 
+    in the `FAT-DeepFFM paper <https://arxiv.org/abs/1905.06336>`. 
+
+    Args:
+        linear_features (list): the list of `Feature Class`, fed to the linear module.
+        cross_features (list): the list of `Feature Class`, fed to the ffm module.
+        embed_dim (int): the dimensionality of categorical value embedding.        
+        mlp_params (dict): the params of the last MLP module, keys include:`{"dims":list, "activation":str, "dropout":float, "output_layer":bool`}
+    """
+    def __init__(self, linear_features, cross_features, embed_dim, mlp_params):
+        super().__init__()        
+        self.linear_features = linear_features
+        self.cross_features = cross_features        
+
+        self.num_fields = len(cross_features)
+        self.num_field_cross = self.num_fields * (self.num_fields - 1) // 2
+
+        self.ffm = FFM(num_fields=self.num_fields, reduce_sum=False)                
+        self.mlp_out = MLP(self.num_field_cross * embed_dim, **mlp_params)
+
+        self.linear_embedding = EmbeddingLayer(linear_features)
+        self.ffm_embedding = EmbeddingLayer(cross_features)
+
+        self.b =torch.nn.Parameter(torch.zeros(1))
+        
+        # This keeping constant value in module on correct device 
+        # url: https://discuss.pytorch.org/t/keeping-constant-value-in-module-on-correct-device/10129
+        fields_offset = torch.arange(0, self.num_fields, dtype=torch.long)
+        self.register_buffer('fields_offset', fields_offset)
+
+
+    def forward(self, x):
+        # compute scores from the linear part of the model, where input is the raw features (Eq. 5, FAT-DeepFFM)
+        y_linear = self.linear_embedding(x, self.linear_features, squeeze_dim=True).sum(1, keepdim=True) #[batch_size, 1]        
+                
+        # gather the embeddings. Each feature value corresponds to multiple embeddings, with multiplicity equal to number of features/fields.
+        # output shape [batch_size, num_field, num_field, emb_dim]
+        x_ffm = {fea.name: x[fea.name].unsqueeze(1) * self.num_fields  + self.fields_offset for fea in self.cross_features}        
+        input_ffm = self.ffm_embedding(x_ffm, self.cross_features, squeeze_dim=False)         
+
+        # compute second order field-aware feature crossings, output shape [batch_size, num_field_cross, emb_dim]
+        em = self.ffm(input_ffm)                                                            
+
+        # compute scores from the ffm part of the model, output shape [batch_size, 1]
+        y_ffm = self.mlp_out(em.flatten(start_dim=1))
+
+        # compute final prediction
+        y = y_linear + y_ffm
+        return torch.sigmoid(y.squeeze(1) + self.b)
+
+
+class FatDeepFFM(nn.Module):
+    """The FAT-DeepFFM model, mentioned in the `FAT-DeepFFM paper
+    <https://arxiv.org/abs/1905.06336>`. It combines DeepFFM with
+    Compose-Excitation Network (CENet) field attention mechanism
+    to highlight the importance of second-order feature crosses.
+
+    Args:
+        linear_features (list): the list of `Feature Class`, fed to the linear module.
+        cross_features (list): the list of `Feature Class`, fed to the ffm module.
+        embed_dim (int): the dimensionality of categorical value embedding.
+        reduction_ratio (int): the between the dimensions of input layer and hidden layer of the CEN MLP module.
+        mlp_params (dict): the params of the last MLP module, keys include:`{"dims":list, "activation":str, "dropout":float, "output_layer":bool`}
+    """
+
+    def __init__(self, linear_features, cross_features, embed_dim, reduction_ratio, mlp_params):
+        super().__init__()        
+        self.linear_features = linear_features
+        self.cross_features = cross_features        
+
+        self.num_fields = len(cross_features)
+        self.num_field_cross = self.num_fields * (self.num_fields - 1) // 2
+
+        self.ffm = FFM(num_fields=self.num_fields, reduce_sum=False)        
+        self.cen = CEN(embed_dim, self.num_field_cross, reduction_ratio)
+        self.mlp_out = MLP(self.num_field_cross * embed_dim, **mlp_params)
+
+        self.linear_embedding = EmbeddingLayer(linear_features)
+        self.ffm_embedding = EmbeddingLayer(cross_features)
+
+        self.b =torch.nn.Parameter(torch.zeros(1))
+
+        fields_offset = torch.arange(0, self.num_fields, dtype=torch.long)
+        self.register_buffer('fields_offset', fields_offset)
+
+    def forward(self, x):
+        # compute scores from the linear part of the model, where input is the raw features (Eq. 5, FAT-DeepFFM)
+        y_linear = self.linear_embedding(x, self.linear_features, squeeze_dim=True).sum(1, keepdim=True) #[batch_size, 1]        
+        
+        # gather the embeddings. Each feature value corresponds to multiple embeddings, with multiplicity is equal to the number of features/fields.
+        # output shape [batch_size, num_field, num_field, emb_dim]
+        x_ffm = {fea.name: x[fea.name].unsqueeze(1) * self.num_fields + self.fields_offset for fea in self.cross_features}        
+        input_ffm = self.ffm_embedding(x_ffm, self.cross_features, squeeze_dim=False)
+
+        # compute second order field-aware feature crossings, output shape [batch_size, num_field_cross, emb_dim]
+        em = self.ffm(input_ffm)
+
+        # rescale FFM embeddings with field attention (Eq.10), output shape [batch_size, num_field_cross * emb_dim]                                                           
+        aem = self.cen(em)
+        
+        # compute scores from the ffm part of the model, output shape [batch_size, 1]
+        y_ffm = self.mlp_out(aem)                                                           
+                
+        # compute final prediction
+        y = y_linear + y_ffm
+        return torch.sigmoid(y.squeeze(1) + self.b)


### PR DESCRIPTION
This is an implementation of the FAT-DeepFFM (Field Attentive Deep Field-aware Factorization Machine) model. 

### Changes:
* **FAT-DeepFFM model** is added together with a new file `models/ranking/deepffm.py`. The implementation follows the arXiv paper (https://arxiv.org/abs/1905.06336). 
* **DeepFFM model** is also added to file `deepffm.py`, as the FAT-DeepFFM model extends the DeepFFM (or NeuralFFM, https://cs.nju.edu.cn/31/60/c1654a209248/page.htm). 
* **FFM module** is added to the `basic/layers.py` file. The Field-aware Factorization Machine module, mentioned in the FFM paper (https://dl.acm.org/doi/abs/10.1145/2959100.2959134) explicitly models multi-channel second-order feature interactions, with each feature filed corresponding to one channel. The FAT-DeepFFM and DeepFFM models are implemented based on this module. 
* **CEN module** is added to `basic/layers.py` file. This is the Compose-Excitation Network module, mentioned in the FAT-DeepFFM paper as a modified version of `Squeeze-and-Excitation Network (SENet) (Hu et al., 2017)`. It is used to highlight (as an attention mechanism) the importance of second-order feature crosses. The FAT-DeepFFM model is implemented based on this module. 
* **Examples** are added to `examples/ranking/run_avazu.py` and `run_criteo.py`. The hyper parameters (if not conflicting with the existing ones) are set according to Section 4.1 of the FAT-DeepFFM paper. Please refer to the paper for the complete setting. 

### Preliminary metrics 
* setting: test AUC with split (0.7, 0.1, 0.2) capped at two epochs
* **avazu full**
   * DeepFFM: 0.7449
   * FAT-DeepFFM: 0.7152
* full experiments are still running for avazu and criteo

### Future work
* Investigate different implementation of the CEN module in the FAT-DeepFFM model. Current implementation of the squeeze operation is based on the description in the original paper, namely 1x1 convolution. There are also other ideas such as [average pooling](https://github.com/PaddlePaddle/PaddleRec/blob/master/models/rank/fat_deepffm/net.py#L97) and [max pooling](https://github.com/p768lwy3/torecsys/blob/master/torecsys/layers/ctr/compose_excitation_network.py#L65).
* Additional signals extracted from the dense features as well as first order embeddings can also be added to the final sigmoid, see [PaddleRec implementation](https://github.com/PaddlePaddle/PaddleRec/blob/master/models/rank/fat_deepffm/net.py) and [torecsys implementations](https://github.com/p768lwy3/torecsys/blob/master/torecsys/models/ctr/fat_deep_ffm.py).
