### PR TITLE
Fix(esmm_example):add one more classification task

### DIFF
--- a/tutorials/Multi_Task.ipynb
+++ b/tutorials/Multi_Task.ipynb
@@ -301,7 +301,7 @@
     "save_dir = '../examples/ranking/data/ali-ccp/saved'\n",
     "if not os.path.exists(save_dir):\n",
     "    os.makedirs(save_dir)\n",
-    "task_types = [\"classification\", \"classification\"] #CTR与CVR均为二分类任务\n",
+    "task_types = [\"classification\", \"classification\", \"classification\"] #CTR与CVR均为二分类任务\n",
     "mtl_trainer = MTLTrainer(model, task_types=task_types, \n",
     "              optimizer_params={\"lr\": learning_rate, \"weight_decay\": weight_decay}, \n",
     "              n_epoch=epoch, earlystop_patience=1, device=device, model_path=save_dir)\n",


### PR DESCRIPTION
According to line110-111 in mtl_trainer.py:
if isinstance(self.model, ESMM):
                loss = sum(loss_list[1:])  #ESSM only compute loss for ctr and ctcvr task
we need to set three classification tasks in task_types to make sure total_loss = loss_{ctr} + loss_{ctcvr}, otherwise, total_loss = loss_{ctr}.