### PR TITLE
feat: add l1/l2 support for trainers

### DIFF
--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -1,0 +1,183 @@
+"""
+Test cases for RegularizationLoss functionality
+"""
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+# Add the project root to Python path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from torch_rechub.basic.loss_func import RegularizationLoss
+
+
+@pytest.fixture(scope="module")
+def simple_model():
+    """Create a simple model fixture for testing."""
+
+    class SimpleModel(nn.Module):
+        """A simple model for testing"""
+
+        def __init__(self):
+            super().__init__()
+            self.embedding = nn.Embedding(100, 10)
+            self.linear1 = nn.Linear(10, 5)
+            self.linear2 = nn.Linear(5, 1)
+
+        def forward(self, x):
+            x = self.embedding(x)
+            x = x.view(x.size(0), -1)
+            x = self.linear1(x)
+            x = self.linear2(x)
+            return x
+
+    return SimpleModel()
+
+
+def test_regularization_loss_no_penalty(simple_model):
+    """Test that zero regularization returns zero loss"""
+    model = simple_model
+    reg_loss_fn = RegularizationLoss(embedding_l1=0.0, embedding_l2=0.0, dense_l1=0.0, dense_l2=0.0)
+
+    loss = reg_loss_fn(model)
+    assert loss == 0.0, "Zero regularization should return zero loss"
+
+
+def test_regularization_loss_embedding_l2(simple_model):
+    """Test embedding L2 regularization"""
+    model = simple_model
+    reg_loss_fn = RegularizationLoss(embedding_l1=0.0, embedding_l2=1.0, dense_l1=0.0, dense_l2=0.0)
+
+    loss = reg_loss_fn(model)
+
+    # Calculate expected loss manually using instance-based identification
+    expected_loss = 0.0
+    for module in model.modules():
+        if isinstance(module, (nn.Embedding, nn.EmbeddingBag)):
+            for param in module.parameters():
+                expected_loss += torch.sum(param**2).item()
+
+    assert abs(loss - expected_loss) < 1e-6, f"Expected {expected_loss}, got {loss}"
+
+
+def test_regularization_loss_embedding_l1(simple_model):
+    """Test embedding L1 regularization"""
+    model = simple_model
+    reg_loss_fn = RegularizationLoss(embedding_l1=1.0, embedding_l2=0.0, dense_l1=0.0, dense_l2=0.0)
+
+    loss = reg_loss_fn(model)
+
+    # Calculate expected loss manually using instance-based identification
+    expected_loss = 0.0
+    for module in model.modules():
+        if isinstance(module, (nn.Embedding, nn.EmbeddingBag)):
+            for param in module.parameters():
+                expected_loss += torch.sum(torch.abs(param)).item()
+
+    assert abs(loss - expected_loss) < 1e-6, f"Expected {expected_loss}, got {loss}"
+
+
+def test_regularization_loss_dense_l2(simple_model):
+    """Test dense L2 regularization"""
+    model = simple_model
+    reg_loss_fn = RegularizationLoss(embedding_l1=0.0, embedding_l2=0.0, dense_l1=0.0, dense_l2=1.0)
+
+    loss = reg_loss_fn(model)
+
+    # Calculate expected loss manually using instance-based identification
+    embedding_params = set()
+    for module in model.modules():
+        if isinstance(module, (nn.Embedding, nn.EmbeddingBag)):
+            for param in module.parameters():
+                embedding_params.add(id(param))
+
+    expected_loss = 0.0
+    for param in model.parameters():
+        if id(param) not in embedding_params:
+            expected_loss += torch.sum(param**2).item()
+
+    assert abs(loss - expected_loss) < 1e-6, f"Expected {expected_loss}, got {loss}"
+
+
+def test_regularization_loss_combined(simple_model):
+    """Test combined regularization"""
+    model = simple_model
+    reg_loss_fn = RegularizationLoss(embedding_l1=0.1, embedding_l2=0.2, dense_l1=0.3, dense_l2=0.4)
+
+    loss = reg_loss_fn(model)
+
+    # Calculate expected loss manually using instance-based identification
+    embedding_params = set()
+    for module in model.modules():
+        if isinstance(module, (nn.Embedding, nn.EmbeddingBag)):
+            for param in module.parameters():
+                embedding_params.add(id(param))
+
+    expected_loss = 0.0
+    for param in model.parameters():
+        if id(param) in embedding_params:
+            expected_loss += 0.1 * torch.sum(torch.abs(param)).item()
+            expected_loss += 0.2 * torch.sum(param**2).item()
+        else:
+            expected_loss += 0.3 * torch.sum(torch.abs(param)).item()
+            expected_loss += 0.4 * torch.sum(param**2).item()
+
+    assert abs(loss - expected_loss) < 1e-4, f"Expected {expected_loss}, got {loss}"
+
+
+def test_regularization_loss_backward(simple_model):
+    """Test that regularization loss can be backpropagated"""
+    model = simple_model
+    reg_loss_fn = RegularizationLoss(embedding_l2=0.01, dense_l2=0.01)
+
+    # Create dummy input and target
+    x = torch.randint(0, 100, (4,))
+    y = torch.randn(4, 1)
+
+    # Forward pass
+    y_pred = model(x)
+    task_loss = nn.MSELoss()(y_pred, y)
+    reg_loss = reg_loss_fn(model)
+    total_loss = task_loss + reg_loss
+
+    # Backward pass - should not raise any errors
+    total_loss.backward()
+
+    # Check that gradients were computed
+    for param in model.parameters():
+        assert param.grad is not None, "Gradients should be computed"
+
+
+def test_regularization_loss_parameter_identification():
+    """Test that embedding and dense parameters are correctly identified"""
+
+    class TestModel(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.user_embedding = nn.Embedding(100, 10)
+            self.item_embed = nn.Embedding(50, 10)  # Should be recognized as embedding by instance type
+            self.dense_layer = nn.Linear(20, 1)
+            self.other_weight = nn.Parameter(torch.randn(5, 5))
+
+    model = TestModel()
+    reg_loss_fn = RegularizationLoss(embedding_l2=1.0, dense_l2=0.0)
+
+    loss = reg_loss_fn(model)
+
+    # Only embedding parameters should contribute (identified by instance type)
+    expected_loss = 0.0
+    for module in model.modules():
+        if isinstance(module, (nn.Embedding, nn.EmbeddingBag)):
+            for param in module.parameters():
+                expected_loss += torch.sum(param**2).item()
+
+    assert abs(loss - expected_loss) < 1e-6
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/torch_rechub/basic/loss_func.py
+++ b/torch_rechub/basic/loss_func.py
@@ -1,5 +1,60 @@
 import torch
 import torch.functional as F
+import torch.nn as nn
+
+
+class RegularizationLoss(nn.Module):
+    """Unified L1/L2 Regularization Loss for embedding and dense parameters.
+    
+    Example:
+        >>> reg_loss_fn = RegularizationLoss(embedding_l2=1e-5, dense_l2=1e-5)
+        >>> # In model's forward or trainer
+        >>> reg_loss = reg_loss_fn(model)
+        >>> total_loss = task_loss + reg_loss
+    """
+
+    def __init__(self, embedding_l1=0.0, embedding_l2=0.0, dense_l1=0.0, dense_l2=0.0):
+        super(RegularizationLoss, self).__init__()
+        self.embedding_l1 = embedding_l1
+        self.embedding_l2 = embedding_l2
+        self.dense_l1 = dense_l1
+        self.dense_l2 = dense_l2
+
+    def forward(self, model):
+        reg_loss = 0.0
+
+        # Register normalization layers
+        norm_params = set()
+        for module in model.modules():
+            if isinstance(module, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.LayerNorm, nn.GroupNorm, nn.InstanceNorm1d, nn.InstanceNorm2d, nn.InstanceNorm3d)):
+                for param in module.parameters():
+                    norm_params.add(id(param))
+
+        # Register embedding layers
+        embedding_params = set()
+        for module in model.modules():
+            if isinstance(module, (nn.Embedding, nn.EmbeddingBag)):
+                for param in module.parameters():
+                    embedding_params.add(id(param))
+
+        for param in model.parameters():
+            if param.requires_grad:
+                # Skip normalization layer parameters
+                if id(param) in norm_params:
+                    continue
+
+                if id(param) in embedding_params:
+                    if self.embedding_l1 > 0:
+                        reg_loss += self.embedding_l1 * torch.sum(torch.abs(param))
+                    if self.embedding_l2 > 0:
+                        reg_loss += self.embedding_l2 * torch.sum(param**2)
+                else:
+                    if self.dense_l1 > 0:
+                        reg_loss += self.dense_l1 * torch.sum(torch.abs(param))
+                    if self.dense_l2 > 0:
+                        reg_loss += self.dense_l2 * torch.sum(param**2)
+
+        return reg_loss
 
 
 class HingeLoss(torch.nn.Module):

--- a/tutorials/DIN.ipynb
+++ b/tutorials/DIN.ipynb
@@ -531,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "39395b69",
    "metadata": {},
    "outputs": [
@@ -653,7 +653,7 @@
     "model = BST(features=features, history_features=history_features, target_features=target_features, mlp_params={\"dims\": [256, 128]})\n",
     "\n",
     "# 模型训练，需要学习率、设备等一般的参数，此外我们还支持earlystoping策略，及时发现过拟合\n",
-    "ctr_trainer = CTRTrainer(model, optimizer_params={\"lr\": 1e-5, \"weight_decay\": 1e-3}, n_epoch=10, earlystop_patience=4, device='cpu', model_path='./')\n",
+    "ctr_trainer = CTRTrainer(model, optimizer_params={\"lr\": 1e-5, \"weight_decay\": 1e-3}, regularization_params={\"embedding_l1\": 1e-6, \"embedding_l2\": 1e-6,}, n_epoch=10, earlystop_patience=4, device='cpu', model_path='./')\n",
     "ctr_trainer.fit(train_dataloader, val_dataloader)\n",
     "\n",
     "# 查看在测试集上的性能\n",

--- a/tutorials/DeepFM.ipynb
+++ b/tutorials/DeepFM.ipynb
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "08997423",
    "metadata": {
     "colab": {
@@ -478,6 +478,7 @@
     "ctr_trainer = CTRTrainer(\n",
     "    model,\n",
     "    optimizer_params={\"lr\": 1e-4, \"weight_decay\": 1e-5},\n",
+    "    regularization_params={\"embedding_l1\": 1e-6, \"embedding_l2\": 1e-6, \"dense_l1\": 0, \"dense_l2\": 1e-6},\n",
     "    n_epoch=1,\n",
     "    earlystop_patience=3,\n",
     "    device='cpu', #如果有gpu，可设置成cuda:0\n",
@@ -685,11 +686,8 @@
    "name": " DeepFM.ipynb",
    "provenance": []
   },
-  "interpreter": {
-   "hash": "2f0699014af7f4c9080a159fe6ab9f0087a283cb8192b31d41a414a088fd29ff"
-  },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "torch-rechub",
    "language": "python",
    "name": "python3"
   },
@@ -703,7 +701,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？
增加了trainer(ctr_trainer, match_trainer, mtl_trainer)对l1/l2正则损失的支持

Briefly describe your changes / 简要描述您的更改
- 在basic.loss_func下增加RegularizationLoss类，对embedding layer和dense layer计算reg loss
- 在tests/下增加了风格统一的单元测试，执行`python tests/test_regularization.py`以验证

## Type of Change / 变更类型

- [ ] 🐛 Bug fix / Bug修复
- [x] ✨ New model/feature / 新模型/功能
- [ ] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护

## Related Issues / 相关Issues
[FEATURE] 缺少l1 l2 lossing #119

Fixes #(issue number) / 修复 #(issue编号)

## How to Test / 如何测试

```python
# 执行以下指令进行测试
python tests/test_regularization.py
```

## Checklist / 检查清单

- [x] Code follows project style (ran `python config/format_code.py`) / 代码遵循项目风格（运行了格式化脚本）
- [x] Added tests for new functionality / 为新功能添加了测试
- [ ] Updated documentation if needed / 如需要已更新文档
- [x] All tests pass locally / 所有测试在本地通过

## Additional Notes / 附加说明

Any other information for reviewers / 给审查者的其他信息 