### PR TITLE
Support padding_idx in embedding initializers

### DIFF
--- a/torch_rechub/basic/features.py
+++ b/torch_rechub/basic/features.py
@@ -35,7 +35,7 @@ class SequenceFeature(object):
 
     def get_embedding_layer(self):
         if not hasattr(self, 'embed'):
-            self.embed = self.initializer(self.vocab_size, self.embed_dim)
+            self.embed = self.initializer(self.vocab_size, self.embed_dim, padding_idx=self.padding_idx)
         return self.embed
 
 
@@ -67,7 +67,7 @@ class SparseFeature(object):
 
     def get_embedding_layer(self):
         if not hasattr(self, 'embed'):
-            self.embed = self.initializer(self.vocab_size, self.embed_dim)
+            self.embed = self.initializer(self.vocab_size, self.embed_dim, padding_idx=self.padding_idx)
         return self.embed
 
 

--- a/torch_rechub/basic/initializers.py
+++ b/torch_rechub/basic/initializers.py
@@ -13,9 +13,11 @@ class RandomNormal(object):
         self.mean = mean
         self.std = std
 
-    def __call__(self, vocab_size, embed_dim):
-        embed = torch.nn.Embedding(vocab_size, embed_dim)
+    def __call__(self, vocab_size, embed_dim, padding_idx=None):
+        embed = torch.nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
         torch.nn.init.normal_(embed.weight, self.mean, self.std)
+        if padding_idx is not None:
+            torch.nn.init.zeros_(embed.weight[padding_idx])
         return embed
 
 
@@ -31,9 +33,11 @@ class RandomUniform(object):
         self.minval = minval
         self.maxval = maxval
 
-    def __call__(self, vocab_size, embed_dim):
-        embed = torch.nn.Embedding(vocab_size, embed_dim)
+    def __call__(self, vocab_size, embed_dim, padding_idx=None):
+        embed = torch.nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
         torch.nn.init.uniform_(embed.weight, self.minval, self.maxval)
+        if padding_idx is not None:
+            torch.nn.init.zeros_(embed.weight[padding_idx])
         return embed
 
 
@@ -49,9 +53,11 @@ class XavierNormal(object):
     def __init__(self, gain=1.0):
         self.gain = gain
 
-    def __call__(self, vocab_size, embed_dim):
-        embed = torch.nn.Embedding(vocab_size, embed_dim)
+    def __call__(self, vocab_size, embed_dim, padding_idx=None):
+        embed = torch.nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
         torch.nn.init.xavier_normal_(embed.weight, self.gain)
+        if padding_idx is not None:
+            torch.nn.init.zeros_(embed.weight[padding_idx])
         return embed
 
 
@@ -67,9 +73,11 @@ class XavierUniform(object):
     def __init__(self, gain=1.0):
         self.gain = gain
 
-    def __call__(self, vocab_size, embed_dim):
-        embed = torch.nn.Embedding(vocab_size, embed_dim)
+    def __call__(self, vocab_size, embed_dim, padding_idx=None):
+        embed = torch.nn.Embedding(vocab_size, embed_dim, padding_idx=padding_idx)
         torch.nn.init.xavier_uniform_(embed.weight, self.gain)
+        if padding_idx is not None:
+            torch.nn.init.zeros_(embed.weight[padding_idx])
         return embed
 
 
@@ -86,7 +94,7 @@ class Pretrained(object):
         self.embedding_weight = torch.FloatTensor(embedding_weight)
         self.freeze = freeze
 
-    def __call__(self, vocab_size, embed_dim):
+    def __call__(self, vocab_size, embed_dim, padding_idx=None):
         assert vocab_size == self.embedding_weight.shape[0] and embed_dim == self.embedding_weight.shape[1]
-        embed = torch.nn.Embedding.from_pretrained(self.embedding_weight, freeze=self.freeze)
+        embed = torch.nn.Embedding.from_pretrained(self.embedding_weight, freeze=self.freeze, padding_idx=padding_idx)
         return embed

--- a/torch_rechub/basic/layers.py
+++ b/torch_rechub/basic/layers.py
@@ -61,6 +61,7 @@ class EmbeddingLayer(nn.Module):
         self.features = features
         self.embed_dict = nn.ModuleDict()
         self.n_dense = 0
+        self.input_mask = InputMask()
 
         for fea in features:
             if fea.name in self.embed_dict:  # exist
@@ -90,7 +91,7 @@ class EmbeddingLayer(nn.Module):
                     pooling_layer = ConcatPooling()
                 else:
                     raise ValueError("Sequence pooling method supports only pooling in %s, got %s." % (["sum", "mean"], fea.pooling))
-                fea_mask = InputMask()(x, fea)
+                fea_mask = self.input_mask(x, fea)
                 if fea.shared_with is None:
                     sparse_emb.append(pooling_layer(self.embed_dict[fea.name](x[fea.name].long()), fea_mask).unsqueeze(1))
                 else:


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

Pass padding_idx through feature -> initializer and zero out padding embeddings. SequenceFeature and SparseFeature now forward padding_idx when creating their embedding layers. Initializer classes (RandomNormal, RandomUniform, XavierNormal, XavierUniform, Pretrained) accept an optional padding_idx, construct Embedding with padding_idx, and zero the corresponding weight row when provided; Pretrained forwards padding_idx to from_pretrained. EmbeddingLayer now reuses a single InputMask instance (self.input_mask) instead of instantiating one per feature. Note: initializer __call__ signatures changed to include padding_idx, which may affect custom initializers.

## Type of Change / 变更类型

- [x 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [ ] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护

## Related Issues / 相关Issues

Fixes #114 

