### PR TITLE
fix data.py

### DIFF
--- a/torch_rechub/utils/data.py
+++ b/torch_rechub/utils/data.py
@@ -445,7 +445,7 @@ class SeqDataset(Dataset):
         Returns:
             tuple: ``(seq_tokens, seq_positions, seq_time_diffs, target)``.
         """
-        return (torch.LongTensor(self.seq_tokens[index]), torch.LongTensor(self.seq_positions[index]), torch.LongTensor(self.seq_time_diffs[index]), torch.LongTensor([self.targets[index]]))
+        return (torch.LongTensor(self.seq_tokens[index]), torch.LongTensor(self.seq_positions[index]), torch.LongTensor(self.seq_time_diffs[index]), torch.tensor(self.targets[index], dtype=torch.long))
 
     def __len__(self):
         """Return the dataset size."""


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

`self.targets[index]` 在 ml-1m 数据集处理后可能是一个 numpy 数组而非标量，`torch.LongTensor([array])` 会产生多维张量，导致 evaluate_ranking 中 int(targets[i]) 失败。改用 `torch.tensor(self.targets[index], dtype=torch.long)` 可以正确处理两种情况。

## Type of Change / 变更类型

- [x] 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [ ] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护

## Related Issues / 相关Issues

Fixes #186 
