### PR TITLE
Update metric.py

### DIFF
--- a/torch_rechub/basic/metric.py
+++ b/torch_rechub/basic/metric.py
@@ -1,9 +1,14 @@
-"""The metric module, it is used to provide some metrics for recommenders.
-Available function:
-- auc_score: compute AUC
-- gauc_score: compute GAUC
-- log_loss: compute LogLoss
-- topk_metrics: compute topk metrics contains 'ndcg', 'mrr', 'recall', 'hit'
+"""Evaluation metrics for recommender systems.
+
+Accuracy metrics:
+- auc_score / gauc_score / log_loss
+- topk_metrics (ndcg, mrr, recall, hit, precision)
+
+Beyond-accuracy metrics:
+- diversity_score: Intra-List Diversity (ILD)
+- coverage_score: Catalog Coverage
+- novelty_score: Mean Self-Information
+
 Authors: Qida Dong, dongjidan@126.com
 """
 from collections import defaultdict
@@ -195,57 +200,175 @@ def log_loss(y_true, y_pred):
     return -score.sum() / len(y_true)
 
 
-def Coverage(y_pred, all_items, topKs=None):
-    """compute the coverage
-        This method measures the diversity of the recommended items
-        and the ability to explore the long-tailed items
-        Arg:
-                y_pred (dict): {userid, item_ids}, the key is user id and the value is the list that contains the items recommended
-                all_items (set): all unique items
-        Return:
-                result (list[float]): the list of coverage scores
-        """
+def diversity_score(y_pred, item_embeddings, topKs=None):
+    """Intra-List Diversity (ILD): average pairwise cosine distance within each user's recommendation list.
+
+    A higher score means the recommended items are more different from each other,
+    indicating the model is not just recommending similar items repeatedly.
+
+    Args:
+        y_pred (dict): {userid: [item_ids]}, recommended items per user
+        item_embeddings (dict or np.ndarray): item vectors. If dict: {item_id: np.array};
+            if 2D array: indexed by item_id (row = item_id)
+        topKs (list or tuple): e.g. [5, 10]
+
+    Return:
+        results (dict): {'Diversity': ['Diversity@5: 0.xxxx', ...]}
+    """
     if topKs is None:
         topKs = [5]
-    result = []
+    results = defaultdict(list)
     for k in topKs:
-        rec_items = set([])
-        for u in y_pred.keys():
-            tmp_items = set(y_pred[u][:k])
-            rec_items = rec_items | tmp_items
-        score = len(rec_items) * 1. / len(all_items)
-        score = round(score, 4)
-        result.append(f'Coverage@{k}: {score}')
-    return result
+        user_diversities = []
+        for u in y_pred:
+            items = y_pred[u][:k]
+            if len(items) < 2:
+                continue
+            # collect embeddings
+            embs = []
+            for item in items:
+                if isinstance(item_embeddings, dict):
+                    if item in item_embeddings:
+                        embs.append(np.array(item_embeddings[item], dtype=np.float64))
+                else:
+                    if item < len(item_embeddings):
+                        embs.append(np.array(item_embeddings[item], dtype=np.float64))
+            if len(embs) < 2:
+                continue
+            embs = np.stack(embs)
+            # cosine similarity matrix
+            norms = np.linalg.norm(embs, axis=1, keepdims=True)
+            norms = np.maximum(norms, 1e-10)
+            normed = embs / norms
+            sim_matrix = normed @ normed.T
+            # average pairwise distance (upper triangle, excluding diagonal)
+            n = len(embs)
+            pair_count = n * (n - 1) / 2
+            dist_sum = (1 - sim_matrix)[np.triu_indices(n, k=1)].sum()
+            user_diversities.append(dist_sum / pair_count)
+        score = round(np.mean(user_diversities), 4) if user_diversities else 0.0
+        results['Diversity'].append(f'Diversity@{k}: {score}')
+    return results
 
 
-# print(Coverage({'0':[0,1,2],'1':[1,3,4]}, {0,1,2,3,4,5}, [2,3]))
+def coverage_score(y_pred, all_items, topKs=None):
+    """Catalog Coverage: fraction of all items that appear in at least one user's recommendation list.
 
-# pred = np.array([  0.3, 0.2, 0.5, 0.9, 0.7, 0.31, 0.8, 0.1, 0.4, 0.6])
-# label = np.array([   1,   0,   0,   1,   0,   0,    1,   0,   0,   1])
-# users_id = np.array([ 2,   1,   0,   2,   1,   0,    0,   2,   1,   1])
+    A higher score means the model recommends a wider variety of items across all users,
+    rather than always recommending the same popular items.
 
-# print('auc: ', auc_score(label, pred))
-# print('gauc: ', gauc_score(label, pred, users_id))
-# print('log_loss: ', log_loss(label, pred))
+    Args:
+        y_pred (dict): {userid: [item_ids]}, recommended items per user
+        all_items (set or list): all unique item ids in the catalog
+        topKs (list or tuple): e.g. [5, 10]
 
-# for mt in ['ndcg', 'mrr', 'recall', 'hit','s']:
-# 	tm = topk_metrics(y_true, y_pred, users_id, 3, metric_type=mt)
-# 	print(f'{mt}: {tm}')
-# y_pred = {'0': [0, 1], '1': [0, 1], '2': [2, 3]}
-# y_true = {'0': [1, 2], '1': [0, 1, 2], '2': [2, 3]}
-# out = topk_metrics(y_true, y_pred, topKs=(1,2))
-# ndcgs = ndcg_score(y_true,y_pred, topKs=(1,2))
-# print(out)
-# print(ndcgs)
+    Return:
+        results (dict): {'Coverage': ['Coverage@5: 0.xxxx', ...]}
+    """
+    if topKs is None:
+        topKs = [5]
+    results = defaultdict(list)
+    for k in topKs:
+        rec_items = set()
+        for u in y_pred:
+            rec_items.update(y_pred[u][:k])
+        score = round(len(rec_items) / len(all_items), 4)
+        results['Coverage'].append(f'Coverage@{k}: {score}')
+    return results
 
-# ground_truth, match_res = np.load("C:\\Users\\dongj\\Desktop/res.npy", allow_pickle=True)
-# print(len(ground_truth),len(match_res))
-# out = topk_metrics(y_true=ground_truth, y_pred=match_res, topKs=[50])
-# print(out)
+
+def novelty_score(y_pred, item_popularity, topKs=None):
+    """Mean Self-Information: measures how "surprising" or niche the recommendations are.
+
+    For each recommended item, self-information = -log2(popularity).
+    Popular items have low self-information; long-tail items have high self-information.
+    A higher novelty score means the model recommends more niche items.
+
+    Args:
+        y_pred (dict): {userid: [item_ids]}, recommended items per user
+        item_popularity (dict): {item_id: float}, interaction probability of each item
+            (e.g. item_count / total_interactions). Values should be in (0, 1].
+        topKs (list or tuple): e.g. [5, 10]
+
+    Return:
+        results (dict): {'Novelty': ['Novelty@5: x.xxxx', ...]}
+    """
+    if topKs is None:
+        topKs = [5]
+    results = defaultdict(list)
+    for k in topKs:
+        user_novelties = []
+        for u in y_pred:
+            items = y_pred[u][:k]
+            if not items:
+                continue
+            self_info = []
+            for item in items:
+                pop = item_popularity.get(item, 1e-10)
+                pop = max(pop, 1e-10)  # avoid log(0)
+                self_info.append(-np.log2(pop))
+            user_novelties.append(np.mean(self_info))
+        score = round(np.mean(user_novelties), 4) if user_novelties else 0.0
+        results['Novelty'].append(f'Novelty@{k}: {score}')
+    return results
+
 
 if __name__ == "__main__":
+    # Test data: 3 users, each with 2 recommended items
     y_pred = {'0': [0, 1], '1': [0, 1], '2': [2, 3]}
     y_true = {'0': [1, 2], '1': [0, 1, 2], '2': [2, 3]}
+
+    # --- Verify existing topk_metrics (hand-calculated) ---
     out = topk_metrics(y_true, y_pred, topKs=(1, 2))
-    print(out)
+    assert out['NDCG'][1] == 'NDCG@2: 0.7956', f"NDCG@2 wrong: {out['NDCG'][1]}"
+    assert out['MRR'][1] == 'MRR@2: 0.8333', f"MRR@2 wrong: {out['MRR'][1]}"
+    assert out['Recall'][1] == 'Recall@2: 0.7222', f"Recall@2 wrong: {out['Recall'][1]}"
+    assert out['Hit'][1] == 'Hit@2: 0.7143', f"Hit@2 wrong: {out['Hit'][1]}"
+    assert out['Precision'][1] == 'Precision@2: 0.8333', f"Precision@2 wrong: {out['Precision'][1]}"
+    print("[PASS] topk_metrics")
+
+    # --- Verify coverage_score ---
+    # @1: rec_items={0,2} -> 2/6=0.3333; @2: rec_items={0,1,2,3} -> 4/6=0.6667
+    all_items = {0, 1, 2, 3, 4, 5}
+    cov = coverage_score(y_pred, all_items, topKs=[1, 2])
+    assert cov['Coverage'][0] == 'Coverage@1: 0.3333', f"Coverage@1 wrong: {cov['Coverage'][0]}"
+    assert cov['Coverage'][1] == 'Coverage@2: 0.6667', f"Coverage@2 wrong: {cov['Coverage'][1]}"
+    print("[PASS] coverage_score")
+
+    # --- Verify diversity_score ---
+    # embs: 0=[1,0,0], 1=[0.9,0.1,0], 2=[0,1,0], 3=[0,0,1]
+    # User0/1: cos_dist(0,1)=0.0061; User2: cos_dist(2,3)=1.0
+    # avg = (0.0061 + 0.0061 + 1.0) / 3 = 0.3374
+    item_embs = {
+        0: [1.0,
+            0.0,
+            0.0],
+        1: [0.9,
+            0.1,
+            0.0],
+        2: [0.0,
+            1.0,
+            0.0],
+        3: [0.0,
+            0.0,
+            1.0],
+    }
+    div = diversity_score(y_pred, item_embs, topKs=[2])
+    assert div['Diversity'][0] == 'Diversity@2: 0.3374', f"Diversity@2 wrong: {div['Diversity'][0]}"
+    # edge case: topK=1 means only 1 item per user, no pairs -> should be 0.0
+    div1 = diversity_score(y_pred, item_embs, topKs=[1])
+    assert div1['Diversity'][0] == 'Diversity@1: 0.0', f"Diversity@1 wrong: {div1['Diversity'][0]}"
+    print("[PASS] diversity_score")
+
+    # --- Verify novelty_score ---
+    # SI(0)=-log2(0.5)=1.0, SI(1)=-log2(0.3)=1.737, SI(2)=-log2(0.05)=4.3219, SI(3)=-log2(0.01)=6.6439
+    # User0/1: mean(1.0,1.737)=1.3685; User2: mean(4.3219,6.6439)=5.4829
+    # avg@2 = (1.3685+1.3685+5.4829)/3 = 2.74
+    item_pop = {0: 0.5, 1: 0.3, 2: 0.05, 3: 0.01}
+    nov = novelty_score(y_pred, item_pop, topKs=[1, 2])
+    assert nov['Novelty'][1] == 'Novelty@2: 2.74', f"Novelty@2 wrong: {nov['Novelty'][1]}"
+    # @1: User0=SI(0)=1.0, User1=SI(0)=1.0, User2=SI(2)=4.3219 -> avg=2.1073
+    assert nov['Novelty'][0] == 'Novelty@1: 2.1073', f"Novelty@1 wrong: {nov['Novelty'][0]}"
+    print("[PASS] novelty_score")
+
+    print("\nAll tests passed.")


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

增加三个指标计算：
* `coverage_score` — 目录覆盖率

	最直观的一个指标。统计所有用户的推荐列表里一共出现了多少个不同的 item，除以整个 item 目录的总数。如果一个模型只会反复推那几个热门商品，coverage 就会很低。这个指标回答的问题是：你的推荐系统有没有能力把长尾商品也推出去？
	
	公式：Coverage@K = |∪ rec_items_topK| / |all_items|

* `diversity_score` — 列表内多样性 (ILD)

	Coverage 看的是全局，diversity 看的是单个用户。对每个用户的 top-K 推荐列表，计算所有 item 两两之间的余弦距离，取平均。如果推荐的全是同类商品（比如全是运动鞋），embedding 很接近，距离就小，diversity 就低。
	
	公式：ILD(u) = (2 / K(K-1)) * Σ (1 - cos_sim(i, j))，然后对所有用户取平均。

	选余弦距离而不是欧氏距离，是因为推荐系统的 embedding 维度和尺度差异大，余弦距离对此更鲁棒。需要传入 item embedding，这在实际使用中很自然——模型训练完本身就有 item embedding。

* `novelty_score` — 新颖性（平均自信息量）

	这个指标衡量推荐结果的"意外程度"。对每个推荐的 item 计算自信息量 -log2(popularity)，popularity 是该 item 的交互概率（交互次数 / 总交互数）。
	
	热门 item（比如 popularity=0.5）的自信息量只有 1 bit，而冷门 item（popularity=0.01）有 6.6 bits。一个只推热门的模型 novelty 很低，说明它没有给用户带来"发现感"。

这三个指标配合原有的准确率指标一起看，能帮助判断一个推荐模型是不是在"准确但无聊"地推荐——AUC 高但只推热门、推荐列表千篇一律。实际业务中往往需要在准确率和这些指标之间做 trade-off。

## Type of Change / 变更类型

- [ ] 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [ ] 📝 Documentation / 文档
- [x] 🔧 Maintenance / 维护
