### PR TITLE
fix: 修复英文首页 Get Started 按钮 404 链接

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,7 +11,7 @@ hero:
   actions:
     - theme: brand
       text: Get Started
-      link: /guide/intro
+      link: /guide/quick_start
     - theme: alt
       text: View Documentation
       link: /guide/intro


### PR DESCRIPTION
## 问题

英文首页 (https://datawhalechina.github.io/torch-rechux/) 的 **Get Started** 和 **View Documentation** 按钮点击后跳转 404。

## 根本原因

`docs/en/index.md` 中的链接使用了 `/en/guide/...` 前缀：
```yaml
link: /en/guide/quick_start  # ❌ 404
link: /en/guide/intro        # ❌ 404
```

但 `config.mts` 配置了路径重写规则：
```ts
rewrites: {
  'en/:rest*': ':rest*'
}
```

这导致英文文档实际访问路径为 `/guide/...`（不含 `/en/` 前缀），因此 `/en/guide/...` 路径不存在。

## 修复

将两个链接中的 `/en/` 前缀移除：
```yaml
link: /guide/intro  # ✅
link: /guide/intro  # ✅
```

## 验证

修复后的地址 https://datawhalechina.github.io/torch-rechub/guide/intro.html 可正常访问。