### PR TITLE
fix: 修复 docs/en/ 下所有 /en/ 前缀内部链接 404

### DIFF
--- a/docs/en/core/intro.md
+++ b/docs/en/core/intro.md
@@ -24,7 +24,7 @@ Torch-RecHub is modular: features, data, models, training, and tools are separat
 
 ## Component Details
 
-- **Feature processing**: `DenseFeature`, `SparseFeature`, `SequenceFeature`. See [Features](/en/core/features).  
-- **Data pipeline**: `TorchDataset`, `PredictDataset`, `DataGenerator`, `MatchDataGenerator`. See [Data](/en/core/data).  
-- **Training & evaluation**: `CTRTrainer`, `MatchTrainer`, `MTLTrainer` (and generative trainer variants). See [Training & Evaluation](/en/core/evaluation).
+- **Feature processing**: `DenseFeature`, `SparseFeature`, `SequenceFeature`. See [Features](/core/features).  
+- **Data pipeline**: `TorchDataset`, `PredictDataset`, `DataGenerator`, `MatchDataGenerator`. See [Data](/core/data).  
+- **Training & evaluation**: `CTRTrainer`, `MatchTrainer`, `MTLTrainer` (and generative trainer variants). See [Training & Evaluation](/core/evaluation).
 

--- a/docs/en/guide/intro.md
+++ b/docs/en/guide/intro.md
@@ -36,31 +36,31 @@ Torch-RecHub adopts a modular design, dividing the core functions of recommendat
 
 Handles different types of features, including dense features, sparse features, and sequence features.
 
-See [Feature Definitions](/en/core/features) for details.
+See [Feature Definitions](/core/features) for details.
 
 ### 2. Data Pipeline
 
 Responsible for data loading, preprocessing, and generating dataloaders, supporting data processing for ranking and matching models.
 
-See [Data Pipeline](/en/core/data) for details.
+See [Data Pipeline](/core/data) for details.
 
 ### 3. Model Library
 
 Implements various recommendation models, including ranking models, matching models, multi-task models, and generative recommendation models.
 
-See [Model Library](/en/models/intro) for details.
+See [Model Library](/models/intro) for details.
 
 ### 4. Training & Evaluation
 
 Provides a unified training interface, supporting model training, evaluation, prediction, and ONNX export.
 
-See [Training & Evaluation](/en/core/evaluation) for details.
+See [Training & Evaluation](/core/evaluation) for details.
 
 ### 5. Development Tools
 
 Provides various utility functions, such as ONNX export, model visualization, callbacks, and loss functions.
 
-See [Development Tools](/en/tools/intro) for details.
+See [Development Tools](/tools/intro) for details.
 
 ## Supported Models
 
@@ -82,16 +82,16 @@ See [Development Tools](/en/tools/intro) for details.
 
 ## Quick Start
 
-To get started with Torch-RecHub, see the [Quick Start](/en/guide/quick_start) page to learn how to install the framework and run your first example.
+To get started with Torch-RecHub, see the [Quick Start](/guide/quick_start) page to learn how to install the framework and run your first example.
 
 ## Production Deployment
 
-Torch-RecHub supports exporting trained models to ONNX format for production deployment. See [Production Deployment](/en/serving/intro) for details.
+Torch-RecHub supports exporting trained models to ONNX format for production deployment. See [Production Deployment](/serving/intro) for details.
 
 ## Community Contribution
 
-We welcome all forms of contributions! See the [Contributing Guide](/en/community/contributing) for detailed contribution guidelines.
+We welcome all forms of contributions! See the [Contributing Guide](/community/contributing) for detailed contribution guidelines.
 
 ## FAQ
 
-If you encounter issues, see the [FAQ](/en/community/faq) page or submit an Issue on GitHub.
+If you encounter issues, see the [FAQ](/community/faq) page or submit an Issue on GitHub.

--- a/docs/en/models/intro.md
+++ b/docs/en/models/intro.md
@@ -60,13 +60,13 @@ Models are organized by stage/task:
 ## Documentation Navigation
 
 - Ranking models: detailed principles, usage, and parameters.  
-  [See ranking docs](/en/models/ranking)
+  [See ranking docs](/models/ranking)
 - Matching models: detailed principles, usage, and parameters.  
-  [See matching docs](/en/models/matching)
+  [See matching docs](/models/matching)
 - Multi-task models: detailed principles, usage, and parameters.  
-  [See multi-task docs](/en/models/mtl)
+  [See multi-task docs](/models/mtl)
 - Generative models: principles, usage, and parameters.  
-  [See generative docs](/en/models/generative)
+  [See generative docs](/models/generative)
 
 ## Usage Examples
 
@@ -102,5 +102,5 @@ trainer.fit(train_dataloader)
 
 ## Contributing New Models
 
-If you want to contribute new models, please refer to the [Contributing Guide](/en/community/contributing) and follow the project's coding standards and documentation requirements.
+If you want to contribute new models, please refer to the [Contributing Guide](/community/contributing) and follow the project's coding standards and documentation requirements.
 

--- a/docs/en/serving/intro.md
+++ b/docs/en/serving/intro.md
@@ -17,10 +17,10 @@ Train Model → ONNX Export → Model Quantization → Vector Index → Online S
 
 | Feature | Description | Documentation |
 | --- | --- | --- |
-| **ONNX Export** | Export PyTorch models to ONNX format | [ONNX Export & Quantization](/en/serving/onnx) |
-| **Model Quantization** | INT8/FP16 quantization to reduce inference latency | [ONNX Export & Quantization](/en/serving/onnx) |
-| **Vector Retrieval** | Annoy/FAISS/Milvus vector indexing | [Vector Retrieval](/en/serving/vector_index) |
-| **Online Service** | Deployment examples and best practices | [Online Service Demo](/en/serving/demo) |
+| **ONNX Export** | Export PyTorch models to ONNX format | [ONNX Export & Quantization](/serving/onnx) |
+| **Model Quantization** | INT8/FP16 quantization to reduce inference latency | [ONNX Export & Quantization](/serving/onnx) |
+| **Vector Retrieval** | Annoy/FAISS/Milvus vector indexing | [Vector Retrieval](/serving/vector_index) |
+| **Online Service** | Deployment examples and best practices | [Online Service Demo](/serving/demo) |
 
 ## Quick Start
 
@@ -80,6 +80,6 @@ User Request → User Tower Inference → Vector Retrieval → Retrieval Results
 
 ## Next Steps
 
-- Learn about [ONNX Export & Quantization](/en/serving/onnx) in detail
-- Learn about [Vector Retrieval](/en/serving/vector_index) configuration
-- Check [Online Service Demo](/en/serving/demo) for complete deployment workflow
+- Learn about [ONNX Export & Quantization](/serving/onnx) in detail
+- Learn about [Vector Retrieval](/serving/vector_index) configuration
+- Check [Online Service Demo](/serving/demo) for complete deployment workflow

--- a/docs/en/tools/intro.md
+++ b/docs/en/tools/intro.md
@@ -11,9 +11,9 @@ Torch-RecHub provides a rich set of development tools to help developers more ef
 
 | Tool Category | Description | Documentation |
 | --- | --- | --- |
-| **Callbacks** | Early stopping, model saving during training | [Callbacks](/en/tools/callbacks) |
-| **Experiment Tracking** | WandB, SwanLab, TensorBoardX integration | [Experiment Tracking](/en/tools/tracking) |
-| **Model Visualization** | Model architecture graph generation and display | [Visualization](/en/tools/visualization) |
+| **Callbacks** | Early stopping, model saving during training | [Callbacks](/tools/callbacks) |
+| **Experiment Tracking** | WandB, SwanLab, TensorBoardX integration | [Experiment Tracking](/tools/tracking) |
+| **Model Visualization** | Model architecture graph generation and display | [Visualization](/tools/visualization) |
 
 ## Callbacks
 
@@ -40,7 +40,7 @@ for epoch in range(n_epoch):
         break
 ```
 
-See [Callbacks](/en/tools/callbacks) for details.
+See [Callbacks](/tools/callbacks) for details.
 
 ## Experiment Tracking
 
@@ -62,7 +62,7 @@ trainer = CTRTrainer(model, model_logger=logger)
 trainer.fit(train_dl, val_dl)
 ```
 
-See [Experiment Tracking](/en/tools/tracking) for details.
+See [Experiment Tracking](/tools/tracking) for details.
 
 ## Model Visualization
 
@@ -78,7 +78,7 @@ graph = visualize_model(model, depth=4)
 visualize_model(model, save_path="model_arch.pdf", dpi=300)
 ```
 
-See [Visualization](/en/tools/visualization) for details.
+See [Visualization](/tools/visualization) for details.
 
 ## Loss Functions
 
@@ -138,7 +138,7 @@ loss = nce_loss(logits, targets)
 
 ## Next Steps
 
-- Learn about [Callbacks](/en/tools/callbacks) in detail
-- Learn about [Experiment Tracking](/en/tools/tracking) configuration
-- Learn about [Visualization](/en/tools/visualization) usage
+- Learn about [Callbacks](/tools/callbacks) in detail
+- Learn about [Experiment Tracking](/tools/tracking) configuration
+- Learn about [Visualization](/tools/visualization) usage
 

--- a/docs/en/tutorials/intro.md
+++ b/docs/en/tutorials/intro.md
@@ -13,9 +13,9 @@ This section provides practical tutorials for Torch-RecHub in different recommen
 
 | Tutorial | Description | Link |
 | --- | --- | --- |
-| **CTR Prediction** | Click-through rate prediction model training | [CTR Prediction Tutorial](/en/tutorials/ctr) |
-| **Matching Models** | Two-tower matching model training | [Matching Models Tutorial](/en/tutorials/retrieval) |
-| **Complete Pipeline** | End-to-end recommendation system | [Complete Pipeline Tutorial](/en/tutorials/pipeline) |
+| **CTR Prediction** | Click-through rate prediction model training | [CTR Prediction Tutorial](/tutorials/ctr) |
+| **Matching Models** | Two-tower matching model training | [Matching Models Tutorial](/tutorials/retrieval) |
+| **Complete Pipeline** | End-to-end recommendation system | [Complete Pipeline Tutorial](/tutorials/pipeline) |
 
 ## Quick Navigation
 
@@ -32,7 +32,7 @@ trainer = CTRTrainer(model)
 trainer.fit(train_dl, val_dl)
 ```
 
-[View Full Tutorial →](/en/tutorials/ctr)
+[View Full Tutorial →](/tutorials/ctr)
 
 ### Matching Models
 
@@ -47,4 +47,4 @@ trainer = MatchTrainer(model)
 trainer.fit(train_dl)
 ```
 
-[View Full Tutorial →](/en/tutorials/retrieval)
+[View Full Tutorial →](/tutorials/retrieval)


### PR DESCRIPTION
## 问题

继 #205 之后，`docs/en/` 目录下多个文档页面中的内部链接仍使用 `/en/` 前缀，如：

```markdown
[Quick Start](/en/guide/quick_start)   ← 404
[Features](/en/core/features)          ← 404
```

由于 `config.mts` 配置了 `rewrites: {'en/:rest*': ':rest*'}`，英文文档的实际访问路径不含 `/en/` 前缀，导致所有此类链接均 404。

## 修复

批量移除 `docs/en/` 下 6 个文件中的 `/en/` 前缀：

| 文件 | 修复数量 |
|------|---------|
| `docs/en/guide/intro.md` | 多处（含用户反馈的 Quick Start 链接） |
| `docs/en/core/intro.md` | 多处 |
| `docs/en/models/intro.md` | 多处 |
| `docs/en/serving/intro.md` | 多处 |
| `docs/en/tools/intro.md` | 多处 |
| `docs/en/tutorials/intro.md` | 多处 |

## 关联

- 跟进 #205（已修复首页 Get Started 按钮）