### PR TITLE
Fix MIND and ComiRec list-wise logits shape

### DIFF
--- a/examples/matching/run_ml_mind.py
+++ b/examples/matching/run_ml_mind.py
@@ -70,7 +70,7 @@ def main(dataset_path, model_name, epoch, learning_rate, batch_size, weight_deca
 
     model = MIND(user_features, history_features, item_features, neg_item_feature, max_length=seq_max_len, temperature=0.02)
 
-    # mode=1 means pair-wise learning
+    # mode=2 means list-wise learning with sampled negatives.
     trainer = MatchTrainer(model, mode=2, optimizer_params={"lr": learning_rate, "weight_decay": weight_decay}, n_epoch=epoch, device=device, model_path=save_dir, gpus=[0])
 
     train_dl, test_dl, item_dl = dg.generate_dataloader(test_user, all_item, batch_size=batch_size, num_workers=0)

--- a/torch_rechub/models/matching/comirec.py
+++ b/torch_rechub/models/matching/comirec.py
@@ -53,13 +53,11 @@ class ComirecSA(torch.nn.Module):
 
         pos_item_embedding = item_embedding[:, 0, :]
         dot_res = torch.bmm(user_embedding, pos_item_embedding.squeeze(1).unsqueeze(-1))
-        k_index = torch.argmax(dot_res, dim=1)
-        best_interest_emb = torch.rand(user_embedding.shape[0], user_embedding.shape[2]).to(user_embedding.device)
-        for k in range(user_embedding.shape[0]):
-            best_interest_emb[k, :] = user_embedding[k, k_index[k], :]
-        best_interest_emb = best_interest_emb.unsqueeze(1)
+        k_index = torch.argmax(dot_res, dim=1).squeeze(-1)
+        batch_index = torch.arange(user_embedding.shape[0], device=user_embedding.device)
+        best_interest_emb = user_embedding[batch_index, k_index, :].unsqueeze(1)
 
-        y = torch.mul(best_interest_emb, item_embedding).sum(dim=1)
+        y = torch.mul(best_interest_emb, item_embedding).sum(dim=-1)
 
         return y
 
@@ -144,13 +142,11 @@ class ComirecDR(torch.nn.Module):
 
         pos_item_embedding = item_embedding[:, 0, :]
         dot_res = torch.bmm(user_embedding, pos_item_embedding.squeeze(1).unsqueeze(-1))
-        k_index = torch.argmax(dot_res, dim=1)
-        best_interest_emb = torch.rand(user_embedding.shape[0], user_embedding.shape[2]).to(user_embedding.device)
-        for k in range(user_embedding.shape[0]):
-            best_interest_emb[k, :] = user_embedding[k, k_index[k], :]
-        best_interest_emb = best_interest_emb.unsqueeze(1)
+        k_index = torch.argmax(dot_res, dim=1).squeeze(-1)
+        batch_index = torch.arange(user_embedding.shape[0], device=user_embedding.device)
+        best_interest_emb = user_embedding[batch_index, k_index, :].unsqueeze(1)
 
-        y = torch.mul(best_interest_emb, item_embedding).sum(dim=1)
+        y = torch.mul(best_interest_emb, item_embedding).sum(dim=-1)
 
         return y
 

--- a/torch_rechub/models/matching/mind.py
+++ b/torch_rechub/models/matching/mind.py
@@ -55,13 +55,11 @@ class MIND(torch.nn.Module):
 
         pos_item_embedding = item_embedding[:, 0, :]
         dot_res = torch.bmm(user_embedding, pos_item_embedding.squeeze(1).unsqueeze(-1))
-        k_index = torch.argmax(dot_res, dim=1)
-        best_interest_emb = torch.rand(user_embedding.shape[0], user_embedding.shape[2]).to(user_embedding.device)
-        for k in range(user_embedding.shape[0]):
-            best_interest_emb[k, :] = user_embedding[k, k_index[k], :]
-        best_interest_emb = best_interest_emb.unsqueeze(1)
+        k_index = torch.argmax(dot_res, dim=1).squeeze(-1)
+        batch_index = torch.arange(user_embedding.shape[0], device=user_embedding.device)
+        best_interest_emb = user_embedding[batch_index, k_index, :].unsqueeze(1)
 
-        y = torch.mul(best_interest_emb, item_embedding).sum(dim=1)
+        y = torch.mul(best_interest_emb, item_embedding).sum(dim=-1)
         return y
 
     def user_tower(self, x):


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个 PR 做了什么？

This PR fixes the forward logits calculation for multi-interest matching models in list-wise training.

Previously, `MIND`, `ComirecSA`, and `ComirecDR` selected the best user interest embedding correctly, but then summed over `dim=1`, which collapses the candidate item dimension. This produced outputs with shape `[batch_size, embed_dim]` instead of the expected `[batch_size, 1 + n_neg_items]` logits required by `CrossEntropyLoss` in `MatchTrainer(mode=2)`.

Changes:
- Replace the Python loop for selecting `best_interest_emb` with batched tensor indexing.
- Compute candidate logits by summing over the embedding dimension with `sum(dim=-1)`.
- Update the `run_ml_mind.py` comment to correctly describe `mode=2` as list-wise learning with sampled negatives.

## Type of Change / 变更类型

- [x] Bug fix / Bug 修复
- [ ] New model/feature / 新模型/功能
- [ ] Documentation / 文档
- [ ] Maintenance / 维护

## Related Issues / 相关 Issues

Fixes #221 

## How to Test / 如何测试

```bash
python run_ml_mind.py --device cpu --epoch 1 --batch_size 32 --save_dir ./data/ml-1m/saved/
```

Run from:

```bash
examples/matching
```

Expected behavior:
- preprocessing completes
- training completes for 1 epoch
- user/item embedding inference completes
- matching evaluation runs without shape errors

Observed output includes:

```text
user_embedding: torch.Size([2, 4, 16])
item_embedding: torch.Size([93, 16])
```

## Checklist / 检查清单

- [x] Code follows project style (ran `python config/format_code.py`)
- [ ] Added tests for new functionality
- [ ] Updated documentation if needed
- [ ] All tests pass locally

## Additional Notes / 附加说明

This fix keeps the existing model behavior of selecting the best interest according to the positive item, but corrects the final dot-product reduction so the model returns one logit per candidate item for list-wise sampled softmax training.

Only targeted example validation was run; the full test suite was not run.
