### PR TITLE
Update README images and add MIND list-wise docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿<div align="center">
 
-![Torch-RecHub Banner](docs/public/img/banner.png)
+![Torch-RecHub Banner](https://raw.githubusercontent.com/datawhalechina/torch-rechub/main/docs/public/img/banner.png)
 
 # Torch-RecHub: A Lightweight, Efficient, and Easy-to-use PyTorch Recommender Framework
 
@@ -18,7 +18,7 @@
 
 English | [简体中文](README_zh.md)
 
-![Project Framework](docs/public/img/project_framework.png)
+![Project Framework](https://raw.githubusercontent.com/datawhalechina/torch-rechub/main/docs/public/img/project_framework.png)
 
 </div>
 

--- a/docs/en/tutorials/models/matching/mind.md
+++ b/docs/en/tutorials/models/matching/mind.md
@@ -20,6 +20,29 @@ MIND (Multi-Interest Network with Dynamic Routing), proposed by Alibaba at CIKM 
 - **User Representation**: multiple interest vectors with shape `[batch_size, interest_num, embed_dim]`
 - **Training**: list-wise softmax training, similar to YoutubeDNN
 
+### List-wise Forward Output
+
+In `mode=2` list-wise training, `neg_item_feature` provides sampled negative items for each sample, and `item_tower` returns candidate item embeddings:
+
+```text
+item_embedding: [batch_size, 1 + n_neg_items, embed_dim]
+```
+
+MIND first uses the positive item to select the most relevant user interest as `best_interest_emb`:
+
+```text
+best_interest_emb: [batch_size, 1, embed_dim]
+```
+
+It then computes one dot-product logit for each candidate item:
+
+```text
+y = (best_interest_emb * item_embedding).sum(dim=-1)
+y: [batch_size, 1 + n_neg_items]
+```
+
+The reduction must be over the embedding dimension `dim=-1`, not over the candidate item dimension. `MatchTrainer(mode=2)` uses `CrossEntropyLoss`, so `y_train = 0` means the first candidate item is the positive item.
+
 ### Suitable Scenarios
 
 - Retrieval stage of recommendation systems

--- a/docs/zh/tutorials/models/matching/mind.md
+++ b/docs/zh/tutorials/models/matching/mind.md
@@ -20,6 +20,29 @@ MIND (Multi-Interest Network with Dynamic Routing) 是阿里妈妈在 CIKM'2019 
 - **User Representation**: 多个兴趣向量（而非一个），维度为 `[batch_size, interest_num, embed_dim]`
 - **训练方式**: List-wise (Softmax)，与 YoutubeDNN 类似
 
+### List-wise 前向输出
+
+在 `mode=2` 的 list-wise 训练中，`neg_item_feature` 会提供每条样本的负样本集合，`item_tower` 返回候选物品向量：
+
+```text
+item_embedding: [batch_size, 1 + n_neg_items, embed_dim]
+```
+
+MIND 会先使用正样本物品从多个用户兴趣向量中选择最相关的 `best_interest_emb`：
+
+```text
+best_interest_emb: [batch_size, 1, embed_dim]
+```
+
+然后对每个候选物品计算内积，输出 sampled softmax 所需的 logits：
+
+```text
+y = (best_interest_emb * item_embedding).sum(dim=-1)
+y: [batch_size, 1 + n_neg_items]
+```
+
+这里必须沿 embedding 维度 `dim=-1` 求和，不能沿候选物品维度求和。`MatchTrainer(mode=2)` 使用 `CrossEntropyLoss`，因此 `y_train = 0` 表示第 0 个候选物品是正样本。
+
 ### 适用场景
 
 - 推荐系统**召回阶段**


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

Replace local README image paths with raw.githubusercontent.com URLs to ensure images render reliably. Add a "List-wise Forward Output" section to the MIND tutorial (English and Chinese) describing item/user embedding shapes, dot-product logits computation (sum over embed dim -1), and that MatchTrainer(mode=2) uses CrossEntropyLoss with y_train = 0 as the positive item.

## Type of Change / 变更类型

- [ ] 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [x] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护
