### PR TITLE
Update DIEN docs, example and refactor AUGRU

### DIFF
--- a/docs/en/models/ranking.md
+++ b/docs/en/models/ranking.md
@@ -474,7 +474,7 @@ model = DIN(
 
 ### Description
 
-DIEN (Deep Interest Evolution Network) models user interest evolution, capturing dynamic changes in user interests.
+DIEN (Deep Interest Evolution Network), proposed by Alibaba at AAAI 2019, extends DIN with an **Interest Extractor Layer** (GRU + auxiliary loss) and an **Interest Evolution Layer** (AUGRU) to model how user interests evolve over time.
 
 ### Paper Reference
 
@@ -484,41 +484,61 @@ Zhou, Guorui, et al. "Deep interest evolution network for click-through rate pre
 
 ### Core Principles
 
-- **GRU**: Uses GRU to capture temporal changes in user interests
-- **Interest Extraction Layer**: Extracts interest sequences from raw behavior sequences
-- **Interest Evolution Layer**: Models dynamic interest evolution using GRU and attention
-- **Interest Activation Layer**: Activates relevant interests based on target item
+- **Interest Extractor Layer**: GRU over behaviour sequences; auxiliary loss supervises each hidden state with positive/negative next-step samples (paper Eq.7)
+- **Interest Evolution Layer**: AUGRU embeds attention into the update gate; attention is softmax-normalised over the full valid sequence (paper Eq.14-16)
+- **Auxiliary Loss**: $L_{aux} = -\frac{1}{N}\sum[\log\sigma(h_t \cdot e^+_{t+1}) + \log(1-\sigma(h_t \cdot e^-_{t+1}))]$
+- **Padding**: index 0 is the padding token; padding positions are excluded from GRU, AUGRU attention, and auxiliary loss; all-padding samples keep zero hidden state
 
 ### Usage
 
 ```python
+from torch_rechub.basic.features import SparseFeature, SequenceFeature
 from torch_rechub.models.ranking import DIEN
 
-sequence_features = [SequenceFeature(name="user_history", vocab_size=10000, embed_dim=32, pooling=None)]
+# padding_idx=0 must be set on target_features — they own the embedding tables
+target_features = [
+    SparseFeature("target_item_id", vocab_size=n_items+1, embed_dim=8, padding_idx=0),
+    SparseFeature("target_cate_id", vocab_size=n_cates+1, embed_dim=8, padding_idx=0),
+]
+history_features = [
+    SequenceFeature("hist_item_id", vocab_size=n_items+1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+    SequenceFeature("hist_cate_id", vocab_size=n_cates+1, embed_dim=8,
+                    pooling="concat", shared_with="target_cate_id", padding_idx=0),
+]
+neg_history_features = [
+    SequenceFeature("neg_hist_item_id", vocab_size=n_items+1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+    SequenceFeature("neg_hist_cate_id", vocab_size=n_cates+1, embed_dim=8,
+                    pooling="concat", shared_with="target_cate_id", padding_idx=0),
+]
 
 model = DIEN(
-    deep_features=sparse_features + dense_features,
-    sequence_features=sequence_features,
-    target_features=sparse_features,
-    mlp_params={"dims": [256, 128, 64], "dropout": 0.2, "activation": "relu"},
-    dien_params={"gru_layers": 2, "attention_dim": 64, "dropout": 0.2}
+    features=features,
+    history_features=history_features,
+    neg_history_features=neg_history_features,
+    target_features=target_features,
+    mlp_params={"dims": [256, 128]},
+    alpha=0.2,
 )
+# CTRTrainer must use loss_mode=False — forward returns (prediction, aux_loss)
 ```
 
 ### Parameters
 
-| Parameter | Type | Description | Default |
-| --- | --- | --- | --- |
-| deep_features | list | Feature list for Deep part | None |
-| sequence_features | list | Sequence feature list | None |
-| target_features | list | Target feature list | None |
-| mlp_params | dict | DNN parameters | None |
-| dien_params | dict | DIEN network parameters | None |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| features | list | User profile / context features fed into the top MLP |
+| history_features | list | Positive behaviour sequences; pooling="concat", padding_idx=0, shared_with=target_feature |
+| neg_history_features | list | Negative-sampled sequences; same constraints as history_features; shared_with must point to target feature |
+| target_features | list | Target item features; padding_idx=0 so the shared embedding table's row 0 is a zero vector |
+| mlp_params | dict | Top MLP params; activation is fixed to dice |
+| alpha | float | Auxiliary loss weight (default 0.2) |
 
 ### Use Cases
 
-- Scenarios with evolving user interests
-- Long sequence interest modeling
+- E-commerce / news recommendation where user interests evolve over time
+- Sequential behaviour data with temporal ordering
 - CTR prediction tasks
 
 ## 12. AutoInt

--- a/docs/en/tutorials/models/ranking/dien.md
+++ b/docs/en/tutorials/models/ranking/dien.md
@@ -5,185 +5,170 @@ description: "Complete Deep Interest Evolution Network tutorial: modeling dynami
 
 # DIEN Tutorial
 
-## 1. Model Overview and Use Cases
+## 1. Model Overview
 
-DIEN (Deep Interest Evolution Network), proposed by Alibaba at AAAI 2019, is an evolution of DIN. DIEN introduces an **Interest Extractor** (GRU) and an **Interest Evolution** module (AUGRU) to model how user interests **change over time**, instead of only doing a weighted sum over historical behaviors.
+DIEN (Deep Interest Evolution Network), proposed by Alibaba at AAAI 2019, extends DIN with sequential interest modelling.
 
 **Paper**: [Deep Interest Evolution Network for Click-Through Rate Prediction](https://arxiv.org/pdf/1809.03672)
 
-### Model Architecture
-
-> **Note**: DIEN contains dynamic GRU-based computation, so `torchview` cannot fully trace its internal graph at the moment.
-
-- **Interest Extractor Layer**: uses GRU to model user behavior sequences
-- **Auxiliary Loss**: uses the next-step behavior as an auxiliary supervision signal
-- **Interest Evolution Layer**: uses AUGRU with target-aware attention to model interest evolution relevant to the current target item
-
-### Suitable Scenarios
-
-- CTR prediction
-- News / e-commerce scenarios where user interests change clearly over time
-- Sequential recommendation tasks with temporally ordered behavior data
+- **Interest Extractor Layer**: GRU over behaviour sequences; auxiliary loss supervises each hidden state with positive/negative next-step samples (paper Eq.7)
+- **Interest Evolution Layer**: AUGRU embeds attention into the update gate; attention is softmax-normalised over the full valid sequence (paper Eq.14-16)
+- **Padding**: index 0 is the padding token; excluded from GRU, AUGRU attention, and auxiliary loss; all-padding samples keep zero hidden state
 
 ---
 
-## 2. Data Preparation and Preprocessing
+## 2. Key Conventions
 
-DIEN uses almost the same data pipeline as DIN and also relies on the sampled **Amazon Electronics** dataset. The additional input is `history_labels`, which marks whether each historical behavior is a positive signal.
+| Convention | Detail |
+|------------|--------|
+| padding index | Sequences are zero-padded (`generate_seq_feature` default). All sequence and target features must set `padding_idx=0`. |
+| shared_with | `history_features` and `neg_history_features` must set `shared_with=<target_feature_name>` — NOT the history feature name. `EmbeddingLayer` only registers `shared_with=None` features as root keys in `embed_dict`. |
+| loss_mode | `CTRTrainer` must use `loss_mode=False` because `forward` returns `(prediction, aux_loss)`. |
+
+---
+
+## 3. Data Preparation
 
 ```python
 import pandas as pd
-import torch
+from sklearn.preprocessing import LabelEncoder
+from torch_rechub.utils.data import generate_seq_feature, df_to_dict
 
-from torch_rechub.basic.features import SparseFeature, SequenceFeature
-from torch_rechub.utils.data import DataGenerator, df_to_dict, generate_seq_feature
+raw = pd.read_csv("examples/ranking/data/amazon-electronics/amazon_electronics_sample.csv")
 
-# Load data
-data = pd.read_csv("examples/ranking/data/amazon-electronics/amazon_electronics_sample.csv")
+# Replicate generate_seq_feature's encoding to build item2cate mapping
+enc_data = raw.copy()
+for feat in enc_data:
+    le = LabelEncoder()
+    enc_data[feat] = le.fit_transform(enc_data[feat]) + 1
+enc_data = enc_data.astype('int32')
+item2cate = enc_data[['item_id','cate_id']].drop_duplicates().set_index('item_id')['cate_id'].to_dict()
+n_items, n_users, n_cates = enc_data['item_id'].max(), enc_data['user_id'].max(), enc_data['cate_id'].max()
 
-# Automatically generate sequence features ordered by timestamp.
 train, val, test = generate_seq_feature(
-    data=data,
-    user_col="user_id",
-    item_col="item_id",
-    time_col="timestamp",
-    item_attribute_cols=["cate_id"],
-    min_item=0,
-    shuffle=True,
+    data=raw, user_col="user_id", item_col="item_id",
+    time_col="time", item_attribute_cols=["cate_id"]
 )
-
-user_num = data["user_id"].max() + 1
-item_num = data["item_id"].max() + 1
-cate_num = data["cate_id"].max() + 1
 ```
 
-### Define Features
+---
+
+## 4. Negative Sequence Construction
 
 ```python
-# Base features (target item + user profile features)
-features = [
-    SparseFeature("user_id", vocab_size=user_num, embed_dim=16),
-    SparseFeature("gender", vocab_size=data["gender"].max() + 1, embed_dim=8),
-    SparseFeature("age", vocab_size=data["age"].max() + 1, embed_dim=8),
-]
+import random
+import numpy as np
 
-# History sequence features
-history_features = [
-    SequenceFeature("hist_item_id", vocab_size=item_num, embed_dim=16, pooling="concat", shared_with="item_id"),
-    SequenceFeature("hist_cate_id", vocab_size=cate_num, embed_dim=16, pooling="concat", shared_with="cate_id"),
-]
+def build_neg_history(split, hist_item_col, item2cate, n_items):
+    """Per-timestep negative sampling: sample a neg item then look up its cate."""
+    seqs = split[hist_item_col]
+    neg_items = np.zeros_like(seqs)
+    neg_cates = np.zeros_like(seqs)
+    for i, row in enumerate(seqs):
+        for t, item in enumerate(row):
+            if item == 0:
+                continue
+            neg = item
+            while neg == item:
+                neg = random.randint(1, n_items)
+            neg_items[i, t] = neg
+            neg_cates[i, t] = item2cate.get(neg, 1)
+    return neg_items, neg_cates
 
+train, val, test = df_to_dict(train), df_to_dict(val), df_to_dict(test)
+train_y, val_y, test_y = train.pop("label"), val.pop("label"), test.pop("label")
+
+for split in [train, val, test]:
+    neg_items, neg_cates = build_neg_history(split, "hist_item_id", item2cate, n_items)
+    split["neg_hist_item_id"] = neg_items
+    split["neg_hist_cate_id"] = neg_cates
+```
+
+---
+
+## 5. Feature Definition
+
+```python
+from torch_rechub.basic.features import SparseFeature, SequenceFeature
+
+features = [SparseFeature("user_id", vocab_size=n_users + 1, embed_dim=8)]
+
+# padding_idx=0 must be on target_features — they own the embedding tables
 target_features = [
-    SparseFeature("item_id", vocab_size=item_num, embed_dim=16),
-    SparseFeature("cate_id", vocab_size=cate_num, embed_dim=16),
+    SparseFeature("target_item_id", vocab_size=n_items + 1, embed_dim=8, padding_idx=0),
+    SparseFeature("target_cate_id", vocab_size=n_cates + 1, embed_dim=8, padding_idx=0),
+]
+history_features = [
+    SequenceFeature("hist_item_id", vocab_size=n_items + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+    SequenceFeature("hist_cate_id", vocab_size=n_cates + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_cate_id", padding_idx=0),
+]
+neg_history_features = [
+    SequenceFeature("neg_hist_item_id", vocab_size=n_items + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+    SequenceFeature("neg_hist_cate_id", vocab_size=n_cates + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_cate_id", padding_idx=0),
 ]
 ```
 
-### Build DataLoaders
+---
+
+## 6. Model and Training
 
 ```python
-x_train, y_train = df_to_dict(train), train["label"].values
-x_val, y_val = df_to_dict(val), val["label"].values
-x_test, y_test = df_to_dict(test), test["label"].values
-
-dg = DataGenerator(x_train, y_train)
-train_dl, val_dl, test_dl = dg.generate_dataloader(
-    x_val=x_val,
-    y_val=y_val,
-    x_test=x_test,
-    y_test=y_test,
-    batch_size=1024,
-)
-```
-
-## 3. Model Configuration and Parameter Notes
-
-### 3.1 Create the Model
-
-```python
+import os
 from torch_rechub.models.ranking import DIEN
+from torch_rechub.trainers import CTRTrainer
+from torch_rechub.utils.data import DataGenerator
 
-# `history_labels` marks whether each historical behavior is a positive signal.
-# In this simplified tutorial we use all ones. In real applications this should
-# come from business labels such as click / purchase / watch / favorite.
-history_labels = torch.ones(len(history_features))
+os.makedirs("./saved/dien", exist_ok=True)
+dg = DataGenerator(train, train_y)
+train_dl, val_dl, test_dl = dg.generate_dataloader(
+    x_val=val, y_val=val_y, x_test=test, y_test=test_y, batch_size=4096
+)
 
 model = DIEN(
     features=features,
     history_features=history_features,
+    neg_history_features=neg_history_features,
     target_features=target_features,
-    mlp_params={"dims": [256, 128], "dropout": 0.2, "activation": "dice"},
-    history_labels=history_labels,
+    mlp_params={"dims": [256, 128]},
     alpha=0.2,
 )
-```
-
-### 3.2 Parameter Details
-
-- `history_labels`: fixed model-level configuration used by the auxiliary loss
-- `alpha`: weight of the auxiliary loss term
-- `pooling="concat"` is still required because DIEN needs the raw sequence
-
-## 4. Training Process and Code Example
-
-```python
-import os
-from torch_rechub.trainers import CTRTrainer
-
-os.makedirs("./saved/dien", exist_ok=True)
 
 trainer = CTRTrainer(
     model,
-    optimizer_params={"lr": 1e-3, "weight_decay": 1e-5},
-    n_epoch=3,
+    optimizer_params={"lr": 1e-3, "weight_decay": 1e-3},
+    n_epoch=5,
     earlystop_patience=2,
     device="cpu",
     model_path="./saved/dien",
+    loss_mode=False,  # forward returns (prediction, aux_loss)
 )
-
 trainer.fit(train_dl, val_dl)
-```
-
-## 5. Evaluation and Result Analysis
-
-```python
 auc = trainer.evaluate(trainer.model, test_dl)
-print(f"DIEN test AUC: {auc:.4f}")
+print(f"Test AUC: {auc:.4f}")
 ```
 
-- DIEN is often more suitable than DIN when long-term sequential evolution matters.
-- It is also heavier than DIN, so the extra gain depends on sequence quality and data scale.
+---
 
-## 6. Tuning Suggestions
+## 7. FAQ
 
-- Tune `alpha` carefully. If the auxiliary loss is too strong, the main objective can suffer.
-- DIEN is more computationally expensive than DIN, so start from smaller hidden sizes and shorter sequences.
-- If the dataset is small, DIN may already be a better trade-off.
+### Q1: Core difference between DIEN and DIN?
+DIN uses target attention for a weighted sum (static). DIEN uses GRU+AUGRU to model temporal interest evolution (dynamic) and adds auxiliary loss to supervise GRU hidden states.
 
-## 7. FAQ and Troubleshooting
+### Q2: Why must `shared_with` point to the target feature?
+`EmbeddingLayer` only registers `shared_with=None` features in `embed_dict`. Since `hist_item_id` itself has `shared_with="target_item_id"`, it is not a root key — `neg_hist_item_id` must also point directly to `"target_item_id"`.
 
-### Q1: What is the core difference between DIEN and DIN?
+### Q3: Why set `padding_idx=0` on target features?
+`history_features` and `neg_history_features` share the target feature's embedding table. Only setting `padding_idx=0` on the table owner (target feature) makes row 0 a true zero vector protected by `nn.Embedding`.
 
-DIN uses target attention over historical behaviors, while DIEN further models how interests evolve with GRU / AUGRU.
+### Q4: Recommended sequence length?
+DIEN scales linearly with sequence length (GRU unrolled step by step). Typical range: 20–50.
 
-### Q2: How should `history_labels` be obtained?
-
-They should be derived from the business definition of positive and negative feedback for each step in the historical sequence.
-
-## 8. Model Visualization
-
-DIEN contains GRU-based dynamic computation, so automatic graph visualization is limited compared with plain MLP models.
-
-## 9. ONNX Export
-
-```python
-trainer.export_onnx(
-    "./saved/dien/dien.onnx",
-    data_loader=test_dl,
-    dynamic_batch=True,
-)
-```
+---
 
 ## Full Example
 
-The snippets above form a complete runnable example. Use them together with the same Amazon Electronics preprocessing flow shown in [examples/ranking/run_amazon_electronics.py](https://github.com/datawhalechina/torch-rechub/blob/main/examples/ranking/run_amazon_electronics.py).
+See [examples/ranking/run_dien.py](../../../../../examples/ranking/run_dien.py) for a complete runnable script.

--- a/docs/zh/models/ranking.md
+++ b/docs/zh/models/ranking.md
@@ -487,7 +487,7 @@ model = DIN(
 
 ### 功能描述
 
-DIEN（Deep Interest Evolution Network）是一种用于建模用户兴趣演化过程的深度网络，能够捕获用户兴趣的动态变化。
+DIEN（Deep Interest Evolution Network）是阿里妈妈在 AAAI'2019 提出的模型，在 DIN 基础上引入**兴趣抽取层**（GRU + 辅助损失）和**兴趣演化层**（AUGRU），建模用户兴趣随时间的动态演化过程。
 
 ### 论文引用
 
@@ -497,43 +497,57 @@ Zhou, Guorui, et al. "Deep interest evolution network for click-through rate pre
 
 ### 核心原理
 
-- **GRU**：使用 GRU 捕捉用户兴趣的时序变化
-- **兴趣抽取层**：从原始行为序列中提取兴趣序列
-- **兴趣演化层**：使用 GRU 和注意力机制建模兴趣的动态演化
-- **兴趣激活层**：根据目标物品激活相关兴趣
+- **兴趣抽取层**：GRU 对行为序列建模，辅助损失用正负样本对监督每步隐状态（论文 Eq.7）
+- **兴趣演化层**：AUGRU 将注意力分数嵌入更新门，对全序列 softmax 归一化后逐步演化（论文 Eq.14-16）
+- **辅助损失**：$L_{aux} = -\frac{1}{N}\sum[\log\sigma(h_t \cdot e^+_{t+1}) + \log(1-\sigma(h_t \cdot e^-_{t+1}))]$
+- **Padding 处理**：padding 位（index=0）不参与 GRU/AUGRU 计算；空历史样本保持零隐状态
 
 ### 使用方法
 
 ```python
+from torch_rechub.basic.features import SparseFeature, SequenceFeature
 from torch_rechub.models.ranking import DIEN
 
-# 定义序列特征
-sequence_features = [SequenceFeature(name="user_history", vocab_size=10000, embed_dim=32, pooling=None)]
+# target_features 必须设 padding_idx=0，因为 history/neg_history 共享其 embedding 表
+target_features = [
+    SparseFeature("target_item_id", vocab_size=n_items+1, embed_dim=8, padding_idx=0),
+]
+# history/neg_history 通过 shared_with 指向 target feature（embed_dict 的 root key）
+history_features = [
+    SequenceFeature("hist_item_id", vocab_size=n_items+1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+]
+neg_history_features = [
+    SequenceFeature("neg_hist_item_id", vocab_size=n_items+1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+]
 
-# 创建模型
 model = DIEN(
-    deep_features=sparse_features + dense_features,
-    sequence_features=sequence_features,
-    target_features=sparse_features,
-    mlp_params={"dims": [256, 128, 64], "dropout": 0.2, "activation": "relu"},
-    dien_params={"gru_layers": 2, "attention_dim": 64, "dropout": 0.2}
+    features=features,
+    history_features=history_features,
+    neg_history_features=neg_history_features,
+    target_features=target_features,
+    mlp_params={"dims": [256, 128]},
+    alpha=0.2,
 )
+# CTRTrainer 需设 loss_mode=False，因为 forward 返回 (prediction, aux_loss)
 ```
 
 ### 参数说明
 
-| 参数 | 类型 | 描述 | 默认值 |
-| --- | --- | --- | --- |
-| deep_features | list | Deep 部分使用的特征列表 | None |
-| sequence_features | list | 序列特征列表 | None |
-| target_features | list | 目标特征列表 | None |
-| mlp_params | dict | 深度神经网络参数 | None |
-| dien_params | dict | DIEN 网络参数 | None |
+| 参数 | 类型 | 描述 |
+| --- | --- | --- |
+| features | list | 用户画像 / 上下文特征，输入顶层 MLP |
+| history_features | list | 正样本行为序列，pooling="concat"，padding_idx=0，shared_with=target_feature |
+| neg_history_features | list | 负采样行为序列，同上，shared_with 必须指向 target feature（非 history feature） |
+| target_features | list | 目标物品特征，padding_idx=0，用于 AUGRU 注意力 |
+| mlp_params | dict | 顶层 MLP 参数，activation 固定为 dice |
+| alpha | float | 辅助损失权重，默认 0.2 |
 
 ### 适用场景
 
-- 用户兴趣动态演化的场景
-- 长序列兴趣建模
+- 用户兴趣随时间动态演化的场景（电商、新闻推荐）
+- 拥有带时序的用户行为序列数据
 - 点击率预测任务
 
 ## 12. AutoInt

--- a/docs/zh/tutorials/models/ranking/dien.md
+++ b/docs/zh/tutorials/models/ranking/dien.md
@@ -5,258 +5,173 @@ description: Deep Interest Evolution Network (DIEN) 模型完整使用教程 —
 
 # DIEN 使用示例
 
-## 1. 模型简介与适用场景
+## 1. 模型简介
 
-DIEN (Deep Interest Evolution Network) 是阿里妈妈在 AAAI'2019 提出的模型，是 DIN 的进化版。DIEN 引入了**兴趣抽取层 (Interest Extractor)**（GRU）和**兴趣演化层 (Interest Evolution)**（AUGRU），能够建模用户兴趣随时间的**动态演化过程**，而不仅仅是对历史行为做加权求和。
+DIEN (Deep Interest Evolution Network) 是阿里妈妈在 AAAI'2019 提出的模型，是 DIN 的进化版。
 
 **论文**: [Deep Interest Evolution Network for Click-Through Rate Prediction](https://arxiv.org/pdf/1809.03672)
 
-### 模型结构
-
-> **注意**: 由于 DIEN 内部使用 GRU 动态计算，torchview 暂时无法自动追踪其计算图，因此未提供架构可视化图。
-
-- **Interest Extractor Layer**: 使用 GRU 对用户行为序列建模，提取每一步的兴趣状态
-- **Auxiliary Loss**: 利用下一时刻的真实点击行为作为监督信号，辅助训练 GRU
-- **Interest Evolution Layer**: 使用 AUGRU (Attention-based Update Gate GRU) 结合目标物品的注意力，建模与目标物品相关的兴趣演化
-
-### 适用场景
-
-- CTR 预估（点击率预测）
-- 用户兴趣随时间有明显变化的场景（如电商、新闻推荐）
-- 拥有丰富的带时序的用户行为序列数据
+- **Interest Extractor Layer**: GRU 对行为序列建模，辅助损失用正负样本对监督每步隐状态（论文 Eq.7）
+- **Interest Evolution Layer**: AUGRU 将注意力嵌入更新门，对全序列 softmax 归一化后演化（论文 Eq.14-16）
+- **辅助损失**: $L_{aux} = -\frac{1}{N}\sum[\log\sigma(h_t \cdot e^+_{t+1}) + \log(1-\sigma(h_t \cdot e^-_{t+1}))]$
+- **Padding 处理**: padding 位（index=0）不参与 GRU/AUGRU 计算；空历史样本保持零隐状态
 
 ---
 
-## 2. 数据准备与预处理
+## 2. 关键约定
 
-DIEN 的数据准备与 DIN 基本一致，同样使用 Amazon Electronics 数据集，但额外需要提供 `history_labels`（历史行为标签，标记每一步是否点击）。
+| 约定 | 说明 |
+|------|------|
+| padding index | 序列用 0 填充（`generate_seq_feature` 默认），所有序列特征和 target 特征都需显式设 `padding_idx=0` |
+| shared_with | `history_features` 和 `neg_history_features` 的 `shared_with` 必须指向 **target feature 的名字**，不能指向 history feature，因为 `EmbeddingLayer` 只把 `shared_with=None` 的特征注册为 embedding root |
+| loss_mode | `CTRTrainer` 需设 `loss_mode=False`，因为 `forward` 返回 `(prediction, aux_loss)` |
+
+---
+
+## 3. 数据准备
 
 ```python
 import pandas as pd
-import torch
+from sklearn.preprocessing import LabelEncoder
+from torch_rechub.utils.data import generate_seq_feature, df_to_dict
 
-from torch_rechub.basic.features import SparseFeature, SequenceFeature
-from torch_rechub.utils.data import DataGenerator, df_to_dict, generate_seq_feature
+raw = pd.read_csv("examples/ranking/data/amazon-electronics/amazon_electronics_sample.csv")
 
-# 加载数据
-data = pd.read_csv("examples/ranking/data/amazon-electronics/amazon_electronics_sample.csv")
+# 复现 generate_seq_feature 内部的编码，用于构建 item2cate 映射
+enc_data = raw.copy()
+for feat in enc_data:
+    le = LabelEncoder()
+    enc_data[feat] = le.fit_transform(enc_data[feat]) + 1
+enc_data = enc_data.astype('int32')
+item2cate = enc_data[['item_id','cate_id']].drop_duplicates().set_index('item_id')['cate_id'].to_dict()
+n_items, n_users, n_cates = enc_data['item_id'].max(), enc_data['user_id'].max(), enc_data['cate_id'].max()
 
-# 自动生成历史序列特征
 train, val, test = generate_seq_feature(
-    data=data, user_col="user_id", item_col="item_id",
+    data=raw, user_col="user_id", item_col="item_id",
     time_col="time", item_attribute_cols=["cate_id"]
-)
-
-n_users = data["user_id"].max()
-n_items = data["item_id"].max()
-n_cates = data["cate_id"].max()
-```
-
-### 定义特征
-
-```python
-# 特征列表（目标物品 + 用户属性）
-features = [
-    SparseFeature("target_item_id", vocab_size=n_items + 1, embed_dim=8),
-    SparseFeature("target_cate_id", vocab_size=n_cates + 1, embed_dim=8),
-    SparseFeature("user_id", vocab_size=n_users + 1, embed_dim=8)
-]
-target_features = features
-
-# 历史行为序列特征
-history_features = [
-    SequenceFeature("hist_item_id", vocab_size=n_items + 1, embed_dim=8,
-                    pooling="concat", shared_with="target_item_id"),
-    SequenceFeature("hist_cate_id", vocab_size=n_cates + 1, embed_dim=8,
-                    pooling="concat", shared_with="target_cate_id")
-]
-```
-
-### 构建 DataLoader
-
-```python
-train_dict, val_dict, test_dict = df_to_dict(train), df_to_dict(val), df_to_dict(test)
-train_y = train_dict.pop("label")
-val_y = val_dict.pop("label")
-test_y = test_dict.pop("label")
-
-dg = DataGenerator(train_dict, train_y)
-train_dl, val_dl, test_dl = dg.generate_dataloader(
-    x_val=val_dict, y_val=val_y, x_test=test_dict, y_test=test_y, batch_size=4096
 )
 ```
 
 ---
 
-## 3. 模型配置与参数说明
-
-### 3.1 创建模型
+## 4. 负样本构造
 
 ```python
-from torch_rechub.models.ranking import DIEN
+import random
+import numpy as np
 
-# history_labels: 标记历史行为序列中每一步是否为正反馈（1=点击，0=未点击）
-# 注意：该参数是模型级别的固定配置，而非逐样本的标签
-# 这里简单使用全 1 表示所有历史行为都是正反馈（简化示例）
-# 实际场景中应根据业务数据设置合理的正负反馈标记
-history_labels = [1] * 50  # 与序列长度一致
+def build_neg_history(split, hist_item_col, item2cate, n_items):
+    """逐时刻采样负 item，再通过 item2cate 查出对应 cate，保证属性一致。"""
+    seqs = split[hist_item_col]
+    neg_items = np.zeros_like(seqs)
+    neg_cates = np.zeros_like(seqs)
+    for i, row in enumerate(seqs):
+        for t, item in enumerate(row):
+            if item == 0:
+                continue
+            neg = item
+            while neg == item:
+                neg = random.randint(1, n_items)
+            neg_items[i, t] = neg
+            neg_cates[i, t] = item2cate.get(neg, 1)
+    return neg_items, neg_cates
+
+train, val, test = df_to_dict(train), df_to_dict(val), df_to_dict(test)
+train_y, val_y, test_y = train.pop("label"), val.pop("label"), test.pop("label")
+
+for split in [train, val, test]:
+    neg_items, neg_cates = build_neg_history(split, "hist_item_id", item2cate, n_items)
+    split["neg_hist_item_id"] = neg_items
+    split["neg_hist_cate_id"] = neg_cates
+```
+
+---
+
+## 5. 特征定义
+
+```python
+from torch_rechub.basic.features import SparseFeature, SequenceFeature
+
+features = [SparseFeature("user_id", vocab_size=n_users + 1, embed_dim=8)]
+
+# padding_idx=0 必须设在 target_features 上，因为 embedding 表由它创建
+target_features = [
+    SparseFeature("target_item_id", vocab_size=n_items + 1, embed_dim=8, padding_idx=0),
+    SparseFeature("target_cate_id", vocab_size=n_cates + 1, embed_dim=8, padding_idx=0),
+]
+
+history_features = [
+    SequenceFeature("hist_item_id", vocab_size=n_items + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+    SequenceFeature("hist_cate_id", vocab_size=n_cates + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_cate_id", padding_idx=0),
+]
+neg_history_features = [
+    SequenceFeature("neg_hist_item_id", vocab_size=n_items + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_item_id", padding_idx=0),
+    SequenceFeature("neg_hist_cate_id", vocab_size=n_cates + 1, embed_dim=8,
+                    pooling="concat", shared_with="target_cate_id", padding_idx=0),
+]
+```
+
+---
+
+## 6. 创建模型与训练
+
+```python
+import os
+from torch_rechub.models.ranking import DIEN
+from torch_rechub.trainers import CTRTrainer
+from torch_rechub.utils.data import DataGenerator
+
+os.makedirs("./saved/dien", exist_ok=True)
+
+dg = DataGenerator(train, train_y)
+train_dl, val_dl, test_dl = dg.generate_dataloader(
+    x_val=val, y_val=val_y, x_test=test, y_test=test_y, batch_size=4096
+)
 
 model = DIEN(
     features=features,
     history_features=history_features,
+    neg_history_features=neg_history_features,
     target_features=target_features,
     mlp_params={"dims": [256, 128]},
-    history_labels=history_labels,  # DIEN 比 DIN 多了一路兴趣演化监督信号
-    alpha=0.2  # 辅助损失权重
+    alpha=0.2,
 )
-```
 
-### 3.2 参数详解
-
-| 参数 | 类型 | 说明 | 建议值 |
-|------|------|------|--------|
-| `features` | `list[Feature]` | 目标物品特征 + 用户特征，同时作为 `target_features` 传入 | |
-| `history_features` | `list[Feature]` | 历史行为序列，pooling 必须为 `"concat"` | |
-| `target_features` | `list[Feature]` | 与 `features` 相同 | |
-| `mlp_params` | `dict` | 顶层 MLP 参数（`activation` 已内置为 `dice`，无需传入） | `{"dims": [256, 128]}` |
-| `history_labels` | `list` | 历史序列中每步的点击标签 (0/1) | 长度与 seq_len 一致 |
-| `alpha` | `float` | 辅助损失的权重系数 | 0.1 ~ 0.5 |
-
-> **关键**: DIEN 的 `forward()` 返回 `(prediction, auxiliary_loss)`，训练器会自动处理辅助损失。
-
----
-
-## 4. 训练过程与代码示例
-
-```python
-import os
-from torch_rechub.trainers import CTRTrainer
-
-os.makedirs("./saved/dien", exist_ok=True)
-
-ctr_trainer = CTRTrainer(
+trainer = CTRTrainer(
     model,
     optimizer_params={"lr": 1e-3, "weight_decay": 1e-3},
     n_epoch=5,
     earlystop_patience=2,
     device="cpu",
-    model_path="./saved/dien"
+    model_path="./saved/dien",
+    loss_mode=False,  # forward 返回 (prediction, aux_loss)
 )
-
-ctr_trainer.fit(train_dl, val_dl)
-```
-
----
-
-## 5. 模型评估与结果分析
-
-```python
-auc = ctr_trainer.evaluate(ctr_trainer.model, test_dl)
+trainer.fit(train_dl, val_dl)
+auc = trainer.evaluate(trainer.model, test_dl)
 print(f"Test AUC: {auc:.4f}")
 ```
 
 ---
 
-## 6. 参数调优建议
-
-1. **辅助损失权重** (`alpha`): 过大会导致主任务训练不充分，过小辅助信号太弱。建议从 `0.2` 开始调整
-2. **激活函数**: MLP 默认使用 `dice`，与 DIN 一致
-3. **序列长度**: DIEN 的计算随序列长度线性增长（GRU），通常限制在 20~50
-
----
-
-## 7. 常见问题与解决方案
+## 7. 常见问题
 
 ### Q1: DIEN 和 DIN 的核心区别？
-- DIN 用 Activation Unit 做加权求和（静态），DIEN 用 GRU+AUGRU 建模兴趣的**时序演化**（动态）
-- DIEN 额外引入辅助损失来监督 GRU 的中间状态
+DIN 用 Activation Unit 做加权求和（静态），DIEN 用 GRU+AUGRU 建模兴趣的时序演化（动态），并引入辅助损失监督 GRU 中间状态。
 
-### Q2: history_labels 如何获取？
-在实际场景中，`history_labels` 来自用户的真实行为反馈（点击/未点击）。在训练数据中，可以根据用户的实际交互记录生成。
+### Q2: shared_with 为什么要指向 target feature 而不是 history feature？
+`EmbeddingLayer` 只把 `shared_with=None` 的特征注册进 `embed_dict`。`history_features` 本身已经 `shared_with="target_*"`，所以 `embed_dict` 里没有 `hist_*` 这个 key，`neg_history_features` 的 `shared_with` 必须直接指向 target feature。
 
----
+### Q3: 为什么 target_features 也要设 padding_idx=0？
+`history_features` 和 `neg_history_features` 共享 target feature 的 embedding 表。只有在 target feature 上设 `padding_idx=0`，embedding 表的 row 0 才真正是受保护的零向量。
 
-## 8. 模型可视化
-
-```python
-from torch_rechub.utils.visualization import visualize_model
-visualize_model(model, save_path="dien_architecture.png", dpi=300)
-```
-
----
-
-## 9. ONNX 导出
-
-```python
-from torch_rechub.utils.onnx_export import ONNXExporter
-exporter = ONNXExporter(model, device="cpu")
-exporter.export("dien.onnx", dynamic_batch=True)
-```
+### Q4: 序列长度建议？
+DIEN 计算随序列长度线性增长（GRU 逐步展开），通常限制在 20~50。
 
 ---
 
 ## 完整代码
 
-```python
-import os
-import pandas as pd
-import torch
-
-from torch_rechub.basic.features import SparseFeature, SequenceFeature
-from torch_rechub.models.ranking import DIEN
-from torch_rechub.trainers import CTRTrainer
-from torch_rechub.utils.data import DataGenerator, df_to_dict, generate_seq_feature
-
-
-def main():
-    torch.manual_seed(2022)
-    os.makedirs("./saved/dien", exist_ok=True)
-
-    data = pd.read_csv("examples/ranking/data/amazon-electronics/amazon_electronics_sample.csv")
-    train, val, test = generate_seq_feature(
-        data=data, user_col="user_id", item_col="item_id",
-        time_col="time", item_attribute_cols=["cate_id"]
-    )
-    n_users, n_items, n_cates = data["user_id"].max(), data["item_id"].max(), data["cate_id"].max()
-
-    features = [
-        SparseFeature("target_item_id", vocab_size=n_items + 1, embed_dim=8),
-        SparseFeature("target_cate_id", vocab_size=n_cates + 1, embed_dim=8),
-        SparseFeature("user_id", vocab_size=n_users + 1, embed_dim=8)
-    ]
-    target_features = features
-    history_features = [
-        SequenceFeature("hist_item_id", vocab_size=n_items + 1, embed_dim=8, pooling="concat", shared_with="target_item_id"),
-        SequenceFeature("hist_cate_id", vocab_size=n_cates + 1, embed_dim=8, pooling="concat", shared_with="target_cate_id")
-    ]
-
-    train_dict, val_dict, test_dict = df_to_dict(train), df_to_dict(val), df_to_dict(test)
-    train_y = train_dict.pop("label")
-    val_y = val_dict.pop("label")
-    test_y = test_dict.pop("label")
-
-    dg = DataGenerator(train_dict, train_y)
-    train_dl, val_dl, test_dl = dg.generate_dataloader(
-        x_val=val_dict, y_val=val_y, x_test=test_dict, y_test=test_y, batch_size=4096
-    )
-
-    history_labels = [1] * 50
-    model = DIEN(
-        features=features, history_features=history_features,
-        target_features=target_features, mlp_params={"dims": [256, 128]},
-        history_labels=history_labels, alpha=0.2
-    )
-
-    ctr_trainer = CTRTrainer(
-        model, optimizer_params={"lr": 1e-3, "weight_decay": 1e-3},
-        n_epoch=2, earlystop_patience=4, device="cpu", model_path="./saved/dien/"
-    )
-    ctr_trainer.fit(train_dl, val_dl)
-
-    auc = ctr_trainer.evaluate(ctr_trainer.model, test_dl)
-    print(f"Test AUC: {auc:.4f}")
-
-
-if __name__ == "__main__":
-    main()
-```
+完整可运行示例见 [examples/ranking/run_dien.py](../../../../../examples/ranking/run_dien.py)。

--- a/examples/ranking/run_dien.py
+++ b/examples/ranking/run_dien.py
@@ -1,0 +1,154 @@
+import random
+import sys
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.preprocessing import LabelEncoder
+
+from torch_rechub.basic.features import SequenceFeature, SparseFeature
+from torch_rechub.models.ranking import DIEN
+from torch_rechub.trainers import CTRTrainer
+from torch_rechub.utils.data import DataGenerator, df_to_dict, generate_seq_feature
+
+sys.path.append("../..")
+
+
+def build_item2cate(data, item_col, cate_col):
+    return data[[item_col, cate_col]].drop_duplicates().set_index(item_col)[cate_col].to_dict()
+
+
+def build_neg_history(split, hist_item_col, item2cate, n_items):
+    """Per-timestep negative sampling: sample a neg item, then look up its cate."""
+    seqs = split[hist_item_col]  # [N, T]
+    neg_items = np.zeros_like(seqs)
+    neg_cates = np.zeros_like(seqs)
+    for i, row in enumerate(seqs):
+        for t, item in enumerate(row):
+            if item == 0:  # padding
+                continue
+            neg = item
+            while neg == item:
+                neg = random.randint(1, n_items)
+            neg_items[i, t] = neg
+            neg_cates[i, t] = item2cate.get(neg, 1)
+    return neg_items, neg_cates
+
+
+def get_data(dataset_path):
+    raw = pd.read_csv(dataset_path)
+    # replicate label encoding done inside generate_seq_feature to build item2cate
+    enc_data = raw.copy()
+    for feat in enc_data:
+        le = LabelEncoder()
+        enc_data[feat] = le.fit_transform(enc_data[feat]) + 1
+    enc_data = enc_data.astype('int32')
+    item2cate = build_item2cate(enc_data, 'item_id', 'cate_id')
+    n_items = enc_data['item_id'].max()
+    n_users = enc_data['user_id'].max()
+    n_cates = enc_data['cate_id'].max()
+
+    train, val, test = generate_seq_feature(data=raw, user_col="user_id", item_col="item_id", time_col="time", item_attribute_cols=["cate_id"])
+
+    features = [SparseFeature("user_id", vocab_size=n_users + 1, embed_dim=8)]
+    target_features = [
+        SparseFeature("target_item_id",
+                      vocab_size=n_items + 1,
+                      embed_dim=8,
+                      padding_idx=0),
+        SparseFeature("target_cate_id",
+                      vocab_size=n_cates + 1,
+                      embed_dim=8,
+                      padding_idx=0),
+    ]
+    history_features = [
+        SequenceFeature("hist_item_id",
+                        vocab_size=n_items + 1,
+                        embed_dim=8,
+                        pooling="concat",
+                        shared_with="target_item_id",
+                        padding_idx=0),
+        SequenceFeature("hist_cate_id",
+                        vocab_size=n_cates + 1,
+                        embed_dim=8,
+                        pooling="concat",
+                        shared_with="target_cate_id",
+                        padding_idx=0),
+    ]
+    neg_history_features = [
+        SequenceFeature("neg_hist_item_id",
+                        vocab_size=n_items + 1,
+                        embed_dim=8,
+                        pooling="concat",
+                        shared_with="target_item_id",
+                        padding_idx=0),
+        SequenceFeature("neg_hist_cate_id",
+                        vocab_size=n_cates + 1,
+                        embed_dim=8,
+                        pooling="concat",
+                        shared_with="target_cate_id",
+                        padding_idx=0),
+    ]
+
+    train, val, test = df_to_dict(train), df_to_dict(val), df_to_dict(test)
+    train_y, val_y, test_y = train.pop("label"), val.pop("label"), test.pop("label")
+
+    for split in [train, val, test]:
+        neg_items, neg_cates = build_neg_history(split, "hist_item_id", item2cate, n_items)
+        split["neg_hist_item_id"] = neg_items
+        split["neg_hist_cate_id"] = neg_cates
+
+    return (features, target_features, history_features, neg_history_features, (train, train_y), (val, val_y), (test, test_y))
+
+
+def main(dataset_path, epoch, learning_rate, batch_size, weight_decay, device, save_dir, seed):
+    torch.manual_seed(seed)
+    features, target_features, history_features, neg_history_features, \
+        (train_x, train_y), (val_x, val_y), (test_x, test_y) = get_data(dataset_path)
+
+    dg = DataGenerator(train_x, train_y)
+    train_dl, val_dl, test_dl = dg.generate_dataloader(x_val=val_x, y_val=val_y, x_test=test_x, y_test=test_y, batch_size=batch_size)
+
+    model = DIEN(
+        features=features,
+        history_features=history_features,
+        neg_history_features=neg_history_features,
+        target_features=target_features,
+        mlp_params={"dims": [256,
+                             128]},
+        alpha=0.2,
+    )
+
+    trainer = CTRTrainer(
+        model,
+        optimizer_params={
+            "lr": learning_rate,
+            "weight_decay": weight_decay
+        },
+        n_epoch=epoch,
+        earlystop_patience=4,
+        device=device,
+        model_path=save_dir,
+        loss_mode=False,
+    )
+    trainer.fit(train_dl, val_dl)
+    auc = trainer.evaluate(trainer.model, test_dl)
+    print(f"test auc: {auc:.4f}")
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_path", default="./data/amazon-electronics/amazon_electronics_sample.csv")
+    parser.add_argument("--epoch", type=int, default=2)
+    parser.add_argument("--learning_rate", type=float, default=1e-3)
+    parser.add_argument("--batch_size", type=int, default=4096)
+    parser.add_argument("--weight_decay", type=float, default=1e-3)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--save_dir", default="./")
+    parser.add_argument("--seed", type=int, default=2022)
+    args = parser.parse_args()
+    main(args.dataset_path, args.epoch, args.learning_rate, args.batch_size, args.weight_decay, args.device, args.save_dir, args.seed)
+"""
+python run_dien.py
+"""

--- a/torch_rechub/models/ranking/dien.py
+++ b/torch_rechub/models/ranking/dien.py
@@ -9,8 +9,32 @@ Authors: Tao Fan, thisisevy@foxmail.com
 import torch
 from torch import nn
 from torch.nn import Parameter, init
+from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 
 from ...basic.layers import MLP, EmbeddingLayer
+
+
+class AUGRU_Cell(nn.Module):
+
+    def __init__(self, embed_dim):
+        super(AUGRU_Cell, self).__init__()
+        self.Wu = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
+        self.Uu = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
+        self.bu = init.xavier_uniform_(Parameter(torch.empty(1, embed_dim)))
+        self.Wr = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
+        self.Ur = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
+        self.br = init.xavier_uniform_(Parameter(torch.empty(1, embed_dim)))
+        self.Wh = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
+        self.Uh = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
+        self.bh = init.xavier_uniform_(Parameter(torch.empty(1, embed_dim)))
+
+    def forward(self, x, h_1, a):
+        # a: [ batch_size, 1 ] — pre-computed attention score for this step
+        u = torch.sigmoid(torch.matmul(x, self.Wu) + torch.matmul(h_1, self.Uu) + self.bu)
+        r = torch.sigmoid(torch.matmul(x, self.Wr) + torch.matmul(h_1, self.Ur) + self.br)
+        h_hat = torch.tanh(torch.matmul(x, self.Wh) + r * torch.matmul(h_1, self.Uh) + self.bh)
+        u_hat = a * u  # attentional update gate (paper Eq.16)
+        return (1 - u_hat) * h_1 + u_hat * h_hat
 
 
 class AUGRU(nn.Module):
@@ -18,174 +42,131 @@ class AUGRU(nn.Module):
     def __init__(self, embed_dim):
         super(AUGRU, self).__init__()
         self.embed_dim = embed_dim
-        # 初始化AUGRU单元
-        self.augru_cell = AUGRU_Cell(self.embed_dim)
-
-    def forward(self, x, item):
-        '''
-        :param x: 输入的序列向量，维度为 [ batch_size, seq_lens, embed_dim ]
-        :param item: 目标物品的向量
-        :return: outs: 所有AUGRU单元输出的隐藏向量[ batch_size, seq_lens, embed_dim ]
-                 h: 最后一个AUGRU单元输出的隐藏向量[ batch_size, embed_dim ]
-        '''
-        outs = []
-        h = None
-        # 开始循环，x.shape[1]是序列的长度
-        for i in range(x.shape[1]):
-            if h is None:
-                # 初始化第一层的输入h
-                h = Parameter(torch.rand(x.shape[0], self.embed_dim).to(x.device))
-            h = self.augru_cell(x[:, i], h, item)
-            outs.append(torch.unsqueeze(h, dim=1))
-        outs = torch.cat(outs, dim=1)
-        return outs, h
-
-
-# AUGRU单元
-class AUGRU_Cell(nn.Module):
-
-    def __init__(self, embed_dim):
-        """
-        :param embed_dim: 输入向量的维度
-        """
-        super(AUGRU_Cell, self).__init__()
-
-        # 初始化更新门的模型参数
-        self.Wu = Parameter(torch.rand(embed_dim, embed_dim))
-        self.Uu = Parameter(torch.rand(embed_dim, embed_dim))
-        self.bu = init.xavier_uniform_(Parameter(torch.empty(1, embed_dim)))
-
-        # 初始化重置门的模型参数
-        self.Wr = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
-        self.Ur = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
-        self.br = init.xavier_uniform_(Parameter(torch.empty(1, embed_dim)))
-
-        # 初始化计算h~的模型参数
-        self.Wh = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
-        self.Uh = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
-        self.bh = init.xavier_uniform_(Parameter(torch.empty(1, embed_dim)))
-
-        # 初始化注意计算里的模型参数
+        self.augru_cell = AUGRU_Cell(embed_dim)
         self.Wa = init.xavier_uniform_(Parameter(torch.empty(embed_dim, embed_dim)))
 
+    def forward(self, x, item, mask=None):
+        # x: [B, T, D], item: [B, D], mask: [B, T] bool (True=valid)
+        scores = torch.matmul(x, self.Wa)  # [B, T, D]
+        scores = (scores * item.unsqueeze(1)).sum(-1)  # [B, T]
+        if mask is not None:
+            scores = scores.masked_fill(~mask, float('-inf'))
+        attn = torch.softmax(scores, dim=1)
+        # replace nan rows (all-padding) with uniform attention
+        nan_rows = attn.isnan().any(dim=1)
+        if nan_rows.any():
+            attn[nan_rows] = 1.0 / attn.size(1)
+        attn = attn.unsqueeze(-1)  # [B, T, 1]
 
-# 注意力的计算
-
-    def attention(self, x, item):
-        '''
-        :param x: 输入的序列中第t个向量 [ batch_size, embed_dim ]
-        :param item: 目标物品的向量 [ batch_size, embed_dim ]
-        :return: 注意力权重 [ batch_size, 1 ]
-        '''
-        hW = torch.matmul(x, self.Wa)
-        hWi = torch.sum(hW * item, dim=1)
-        hWi = torch.unsqueeze(hWi, 1)
-        return torch.softmax(hWi, dim=1)
-
-    def forward(self, x, h_1, item):
-        '''
-        :param x:  输入的序列中第t个物品向量 [ batch_size, embed_dim ]
-        :param h_1:  上一个AUGRU单元输出的隐藏向量 [ batch_size, embed_dim ]
-        :param item: 目标物品的向量 [ batch_size, embed_dim ]
-        :return: h 当前层输出的隐藏向量 [ batch_size, embed_dim ]
-        '''
-        # [ batch_size, embed_dim ]
-        u = torch.sigmoid(torch.matmul(x, self.Wu) + torch.matmul(h_1, self.Uu) + self.bu)
-        # [ batch_size, embed_dim ]
-        r = torch.sigmoid(torch.matmul(x, self.Wr) + torch.matmul(h_1, self.Ur) + self.br)
-        # [ batch_size, embed_dim ]
-        h_hat = torch.tanh(torch.matmul(x, self.Wh) + r * torch.matmul(h_1, self.Uh) + self.bh)
-        # [ batch_size, 1 ]
-        a = self.attention(x, item)
-        # [ batch_size, embed_dim ]
-        u_hat = a * u
-        # [ batch_size, embed_dim ]
-        h = (1 - u_hat) * h_1 + u_hat * h_hat
-        # [ batch_size, embed_dim ]
-        return h
+        h = torch.zeros(x.size(0), self.embed_dim, device=x.device)
+        outs = []
+        for i in range(x.size(1)):
+            h = self.augru_cell(x[:, i], h, attn[:, i])
+            outs.append(h.unsqueeze(1))
+        return torch.cat(outs, dim=1), h
 
 
 class DIEN(nn.Module):
-    """Deep Interest Evolution Network
+    """Deep Interest Evolution Network (AAAI 2019).
+
     Args:
-        features (list): the list of `Feature Class`. training by MLP. It means the user profile features and context features in origin paper, exclude history and target features.
-        history_features (list): the list of `Feature Class`,training by ActivationUnit. It means the user behaviour sequence features, eg.item id sequence, shop id sequence.
-        target_features (list): the list of `Feature Class`, training by ActivationUnit. It means the target feature which will execute target-attention with history feature.
-        mlp_params (dict): the params of the last MLP module, keys include:`{"dims":list, "activation":str, "dropout":float, "output_layer":bool`}
-        history_labels (list): the list of history_features whether it is clicked history or not. It should be 0 or 1.
-        alpha (float): the weighting of auxiliary loss.
+        features (list): user profile / context features fed into the top MLP.
+        history_features (list): positive behaviour sequence features (SequenceFeature, pooling="concat").
+            Must set padding_idx=0 and shared_with=<target_feature_name> so the embedding table
+            is owned by the corresponding target feature.
+        neg_history_features (list): negative-sampled behaviour sequence features, one per history feature.
+            Must set padding_idx=0 and shared_with=<target_feature_name> (same root as history_features).
+            EmbeddingLayer only registers features with shared_with=None as root keys in embed_dict,
+            so shared_with must point to the target feature, NOT the history feature.
+        target_features (list): target item features used by the AUGRU attention.
+            Must set padding_idx=0 so the shared embedding table's row 0 is a true zero vector.
+        mlp_params (dict): params for the top MLP, e.g. {"dims": [256, 128]}.
+            activation is fixed to "dice" as in the paper.
+        alpha (float): weight of the auxiliary loss. Default 0.2.
+
+    Returns (forward):
+        tuple(prediction: Tensor[B], aux_loss: Tensor[])
+
+    Notes:
+        - Sequences are padded with 0 (convention from generate_seq_feature).
+        - Samples with all-padding history keep zero hidden state throughout GRU and AUGRU.
+        - Auxiliary loss uses next-step positive/negative supervision (paper Eq.7), skipping padding positions.
+        - AUGRU attention is softmax-normalised over the full valid sequence (paper Eq.14-15).
     """
 
-    def __init__(self, features, history_features, target_features, mlp_params, history_labels, alpha=0.2):
+    def __init__(self, features, history_features, neg_history_features, target_features, mlp_params, alpha=0.2):
         super().__init__()
-        self.alpha = alpha  # 计算辅助损失函数时的权重
+        self.alpha = alpha
         self.features = features
         self.history_features = history_features
+        self.neg_history_features = neg_history_features
         self.target_features = target_features
-        self.num_history_features = len(history_features)
         self.all_dims = sum([fea.embed_dim for fea in features + history_features + target_features])
-        # self.GRU = nn.GRU(batch_first=True)
-        self.embedding = EmbeddingLayer(features + history_features + target_features)
-        self.interest_extractor_layers = nn.ModuleList([nn.GRU(fea.embed_dim, fea.embed_dim, batch_first=True) for fea in self.history_features])
-        self.interest_evolving_layers = nn.ModuleList([AUGRU(fea.embed_dim) for fea in self.history_features])
-
+        self.embedding = EmbeddingLayer(features + history_features + neg_history_features + target_features)
+        self.interest_extractor_layers = nn.ModuleList([nn.GRU(fea.embed_dim, fea.embed_dim, batch_first=True) for fea in history_features])
+        self.interest_evolving_layers = nn.ModuleList([AUGRU(fea.embed_dim) for fea in history_features])
         self.mlp = MLP(self.all_dims, activation="dice", **mlp_params)
-        self.history_labels = torch.Tensor(history_labels)
         self.BCELoss = nn.BCELoss()
 
-
-# # 注意力计算中的线性层
-# self.attention_liner = nn.Linear(self.embed_dim, t)
-# # AFM公式中的h
-# self.h = init.xavier_uniform_(Parameter(torch.empty(t, 1)))
-# # AFM公式中的p
-# self.p = init.xavier_uniform_(Parameter(torch.empty(self.embed_dim, 1)))
-
-    def auxiliary(self, outs, history_features, history_labels):
-        '''
-        :param history_features: 历史序列物品的向量 [ batch_size, len_seqs, dim ]
-        :param outs: 兴趣抽取层GRU网络输出的outs [ batch_size, len_seqs, dim ]
-        :param history_labels: 历史序列物品标注 [ batch_size, len_seqs, 1 ]
-        :return: 辅助损失函数
-        '''
-        # [ batch_size * len_seqs, dim ]
-        history_features = history_features.reshape(-1, history_features.shape[2])
-        # [ batch_size * len_seqs, dim ]
-        outs = outs.reshape(-1, outs.shape[2])
-        # [ batch_size * len_seqs ]
-        out = torch.sum(outs * history_features, dim=1)
-        # [ batch_size * len_seqs, 1 ]
-        out = torch.unsqueeze(torch.sigmoid(out), 1)
-        # [ batch_size * len_seqs,1 ]
-        history_labels = history_labels.reshape(-1, 1).float()
-        return self.BCELoss(out, history_labels)
+    def auxiliary(self, outs, pos_emb, neg_emb, mask=None):
+        # outs, pos_emb, neg_emb: [B, T, D]
+        # mask: [B, T] bool, True=valid; shift by 1: use h[t] to predict e[t+1]
+        h = outs[:, :-1]
+        pos = pos_emb[:, 1:]
+        neg = neg_emb[:, 1:]
+        if mask is not None:
+            valid = mask[:, :-1] & mask[:, 1:]  # [B, T-1]
+        else:
+            valid = torch.ones(h.size(0), h.size(1), dtype=torch.bool, device=h.device)
+        h, pos, neg = h[valid], pos[valid], neg[valid]
+        if h.size(0) == 0:
+            return torch.tensor(0.0, device=outs.device)
+        pos_score = torch.sigmoid((h * pos).sum(-1, keepdim=True))
+        neg_score = torch.sigmoid((h * neg).sum(-1, keepdim=True))
+        return (self.BCELoss(pos_score, torch.ones_like(pos_score)) + self.BCELoss(neg_score, torch.zeros_like(neg_score)))
 
     def forward(self, x):
-        # (batch_size, num_features, emb_dim)
         embed_x_features = self.embedding(x, self.features)
-        # (batch_size, num_history_features, seq_length, emb_dim)
         embed_x_history = self.embedding(x, self.history_features)
-        # (batch_size, num_target_features, emb_dim)
+        embed_x_neg_history = self.embedding(x, self.neg_history_features)
         embed_x_target = self.embedding(x, self.target_features)
 
         interest_extractor = []
         auxi_loss = 0
-        for i in range(self.num_history_features):
-            outs, _ = self.interest_extractor_layers[i](embed_x_history[:, i, :, :])
-            # 利用GRU输出的outs得到辅助损失函数
-            auxi_loss += self.auxiliary(outs, embed_x_history[:, i, :, :], self.history_labels)
-            # (batch_size, 1, seq_length, emb_dim)
+        for i, fea in enumerate(self.history_features):
+            seq = embed_x_history[:, i, :, :]
+            mask = self.embedding.input_mask(x, fea).squeeze(1).bool()  # [B, T]
+            seq_lens = mask.sum(dim=1).cpu()
+
+            has_hist = seq_lens > 0
+            outs = torch.zeros_like(seq)
+            if has_hist.any():
+                packed = pack_padded_sequence(seq[has_hist], seq_lens[has_hist].clamp(min=1), batch_first=True, enforce_sorted=False)
+                packed_out, _ = self.interest_extractor_layers[i](packed)
+                unpacked, _ = pad_packed_sequence(packed_out, batch_first=True, total_length=seq.size(1))
+                outs[has_hist] = unpacked
+
+            auxi_loss += self.auxiliary(outs, seq, embed_x_neg_history[:, i, :, :], mask)
             interest_extractor.append(outs.unsqueeze(1))
-        # (batch_size, num_history_features, seq_length, emb_dim)
+
         interest_extractor = torch.cat(interest_extractor, dim=1)
+
         interest_evolving = []
-        for i in range(self.num_history_features):
-            _, h = self.interest_evolving_layers[i](interest_extractor[:, i, :, :], embed_x_target[:, i, :])
-            interest_evolving.append(h.unsqueeze(1))  # (batch_size, 1, emb_dim)
-        # (batch_size, num_history_features, emb_dim)
+        for i, fea in enumerate(self.history_features):
+            mask = self.embedding.input_mask(x, fea).squeeze(1).bool()  # [B, T]
+            has_hist = mask.any(dim=1)
+            h = torch.zeros(mask.size(0), self.interest_evolving_layers[i].embed_dim, device=mask.device)
+            if has_hist.any():
+                _, h_valid = self.interest_evolving_layers[i](interest_extractor[has_hist, i, :, :], embed_x_target[has_hist, i, :], mask[has_hist])
+                h[has_hist] = h_valid
+            interest_evolving.append(h.unsqueeze(1))
+
         interest_evolving = torch.cat(interest_evolving, dim=1)
-
-        mlp_in = torch.cat([interest_evolving.flatten(start_dim=1), embed_x_target.flatten(start_dim=1), embed_x_features.flatten(start_dim=1)], dim=1)  # (batch_size, N)
+        mlp_in = torch.cat([
+            interest_evolving.flatten(start_dim=1),
+            embed_x_target.flatten(start_dim=1),
+            embed_x_features.flatten(start_dim=1),
+        ],
+                           dim=1)
         y = self.mlp(mlp_in)
-
         return torch.sigmoid(y.squeeze(1)), self.alpha * auxi_loss


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

Enrich DIEN documentation (EN/CN) and tutorial with detailed architecture, conventions (padding_idx/shared_with/loss_mode), usage examples and negative-sampling guidance. Add a runnable example script examples/ranking/run_dien.py that prepares data, builds negative histories, defines features and trains DIEN with CTRTrainer (loss_mode=False). Refactor torch_rechub/models/ranking/dien.py: rewrite AUGRU/AUGRU_Cell (move attention out of cell), use Xavier init, add masking/NaN-safe softmax, precompute attention scores, return sequence outputs, and add support for neg_history_features; update DIEN constructor/docstring and auxiliary-loss notes. Miscellaneous fixes to API examples and parameter defaults in docs to clarify correct embedding/sharing/padding usage.

## Type of Change / 变更类型

- [x] 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [x] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护

## Related Issues / 相关Issues

Fixes #228 

## How to Test / 如何测试

```python
python ./examples/ranking/run_dien.py   
```

## Checklist / 检查清单

- [x] Code follows project style (ran `python config/format_code.py`) / 代码遵循项目风格（运行了格式化脚本）
- [x] Added tests for new functionality / 为新功能添加了测试
- [x] Updated documentation if needed / 如需要已更新文档
- [x] All tests pass locally / 所有测试在本地通过
