### PR TITLE
Refactor BST transformer; bump PyTorch to 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ![issues](https://img.shields.io/github/issues/datawhalechina/torch-rechub?style=for-the-badge&color=orange)
 
 [![python](https://img.shields.io/badge/python-3.9%2B-3776AB?style=for-the-badge)](https://www.python.org/)
-[![pytorch](https://img.shields.io/badge/pytorch-1.7%2B-EE4C2C?style=for-the-badge)](https://pytorch.org/)
+[![pytorch](https://img.shields.io/badge/pytorch-1.10%2B-EE4C2C?style=for-the-badge)](https://pytorch.org/)
 [![torchview](https://img.shields.io/badge/torchview-0.2%2B-6CB33F?style=for-the-badge)](https://github.com/mert-kurttutan/torchview)
 
 English | [简体中文](README_zh.md)
@@ -67,7 +67,7 @@ English | [简体中文](README_zh.md)
 ### Requirements
 
 * Python 3.9+
-* PyTorch 1.7+ (CUDA-enabled version recommended for GPU acceleration)
+* PyTorch 1.10+ (CUDA-enabled version recommended for GPU acceleration)
 * NumPy
 * Pandas
 * SciPy

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,7 +13,7 @@
 ![issues](https://img.shields.io/github/issues/datawhalechina/torch-rechub?style=for-the-badge&color=orange)
 
 [![python](https://img.shields.io/badge/python-3.9%2B-3776AB?style=for-the-badge)](https://www.python.org/)
-[![pytorch](https://img.shields.io/badge/pytorch-1.7%2B-EE4C2C?style=for-the-badge)](https://pytorch.org/)
+[![pytorch](https://img.shields.io/badge/pytorch-1.10%2B-EE4C2C?style=for-the-badge)](https://pytorch.org/)
 [![torchview](https://img.shields.io/badge/torchview-0.2%2B-6CB33F?style=for-the-badge)](https://github.com/mert-kurttutan/torchview)
 
 [English](README.md) | 简体中文
@@ -67,7 +67,7 @@
 ### 环境要求
 
 * Python 3.9+
-* PyTorch 1.7+ (建议使用支持 CUDA 的版本以获得 GPU 加速)
+* PyTorch 1.10+ (建议使用支持 CUDA 的版本以获得 GPU 加速)
 * NumPy
 * Pandas
 * SciPy

--- a/torch_rechub/models/ranking/bst.py
+++ b/torch_rechub/models/ranking/bst.py
@@ -44,8 +44,7 @@ class BST(nn.Module):
         # positional encoding: absolute index (simplified from paper's time-diff pos)
         self.pos_embedding = nn.Embedding(max_seq_len, self.item_dim)
         # paper uses LeakyReLU in FFN
-        encoder_layer = nn.TransformerEncoderLayer(d_model=self.item_dim, nhead=nhead, dropout=dropout,
-                                                   activation=nn.LeakyReLU(), batch_first=True)
+        encoder_layer = nn.TransformerEncoderLayer(d_model=self.item_dim, nhead=nhead, dropout=dropout, activation=nn.LeakyReLU(), batch_first=True)
         self.transformer_layers = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
         self.mlp = MLP(self.all_dims, **mlp_params)
 
@@ -84,6 +83,7 @@ class BST(nn.Module):
             interest,
             embed_x_target.flatten(start_dim=1),
             embed_x_features.flatten(start_dim=1),
-        ], dim=1)
+        ],
+                           dim=1)
         y = self.mlp(mlp_in)
         return torch.sigmoid(y.squeeze(1))

--- a/torch_rechub/models/ranking/bst.py
+++ b/torch_rechub/models/ranking/bst.py
@@ -24,46 +24,66 @@ class BST(nn.Module):
         nhead (int): the number of heads in the multi-head-attention models.
         dropout (float): the dropout value in the multi-head-attention models.
         num_layers (Any): the number of sub-encoder-layers in the encoder.
+        max_seq_len (int): maximum sequence length (history + 1 target). Used for positional encoding table size.
     """
 
-    def __init__(self, features, history_features, target_features, mlp_params, nhead=8, dropout=0.2, num_layers=1):
+    def __init__(self, features, history_features, target_features, mlp_params, nhead=8, dropout=0.2, num_layers=1, max_seq_len=51):
         super(BST, self).__init__()
         self.features = features
         self.history_features = history_features
         self.target_features = target_features
-        self.nhead = nhead
-        self.dropout = dropout
-        self.num_layers = num_layers
-        self.num_history_features = len(history_features)
-        self.embed_dim = history_features[0].embed_dim
-        self.all_dims = sum([fea.embed_dim for fea in features + history_features + target_features])
-
+        self.max_seq_len = max_seq_len
+        self.item_dim = sum([fea.embed_dim for fea in history_features])
+        target_dim = sum([fea.embed_dim for fea in target_features])
+        if self.item_dim != target_dim:
+            raise ValueError(f"sum of history_features embed_dim ({self.item_dim}) must equal sum of target_features embed_dim ({target_dim})")
+        if self.item_dim % nhead != 0:
+            raise ValueError(f"item_dim ({self.item_dim}) must be divisible by nhead ({nhead})")
+        self.all_dims = sum([fea.embed_dim for fea in features + target_features]) + self.item_dim
         self.embedding = EmbeddingLayer(features + history_features + target_features)
-        self.encoder_layer = nn.TransformerEncoderLayer(
-            d_model=self.embed_dim,
-            nhead=nhead,
-            dropout=dropout,
-            batch_first=True,
-        )
-        self.transformer_layers = nn.TransformerEncoder(self.encoder_layer, num_layers=num_layers)
+        # positional encoding: absolute index (simplified from paper's time-diff pos)
+        self.pos_embedding = nn.Embedding(max_seq_len, self.item_dim)
+        # paper uses LeakyReLU in FFN
+        encoder_layer = nn.TransformerEncoderLayer(d_model=self.item_dim, nhead=nhead, dropout=dropout,
+                                                   activation=nn.LeakyReLU(), batch_first=True)
+        self.transformer_layers = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
         self.mlp = MLP(self.all_dims, **mlp_params)
 
     def forward(self, x):
-        # (batch_size, num_features, emb_dim)
         embed_x_features = self.embedding(x, self.features)
         # (batch_size, num_history_features, seq_length, emb_dim)
         embed_x_history = self.embedding(x, self.history_features)
         # (batch_size, num_target_features, emb_dim)
         embed_x_target = self.embedding(x, self.target_features)
-        transformer_pooling = []
-        for i in range(self.num_history_features):
-            # (batch_size, seq_length + num_target_features, emb_dim)
-            transformer_seq = self.transformer_layers(torch.cat([embed_x_history[:, i, :, :], embed_x_target], dim=1))
-            # (batch_size, emb_dim)
-            transformer_pooling.append(torch.mean(transformer_seq, dim=1).unsqueeze(1))
-        # (batch_size, num_history_features, emb_dim)
-        transformer_pooling = torch.cat(transformer_pooling, dim=1)
 
-        mlp_in = torch.cat([transformer_pooling.flatten(start_dim=1), embed_x_target.flatten(start_dim=1), embed_x_features.flatten(start_dim=1)], dim=1)  # (batch_size, N)
+        # fuse all history features into one item vector per timestep: [B, T, item_dim]
+        hist = torch.cat([embed_x_history[:, i] for i in range(len(self.history_features))], dim=-1)
+        # fuse target features into one vector: [B, item_dim]
+        tgt = torch.cat([embed_x_target[:, i] for i in range(len(self.target_features))], dim=-1)
+
+        # append target at end of sequence: [B, T+1, item_dim]
+        seq = torch.cat([hist, tgt.unsqueeze(1)], dim=1)
+        if seq.size(1) > self.max_seq_len:
+            raise ValueError(f"sequence length {seq.size(1)} exceeds max_seq_len {self.max_seq_len}")
+        positions = torch.arange(seq.size(1), device=seq.device).unsqueeze(0)
+        seq = seq + self.pos_embedding(positions)
+
+        # padding mask: a position is padding only if ALL history features are padding there
+        pad_mask = torch.ones(embed_x_history.size(0), embed_x_history.size(2), dtype=torch.bool, device=embed_x_history.device)
+        for fea in self.history_features:
+            pidx = fea.padding_idx if fea.padding_idx is not None else 0
+            pad_mask = pad_mask & (x[fea.name].long() == pidx)
+        tgt_mask = torch.zeros(pad_mask.size(0), 1, dtype=torch.bool, device=pad_mask.device)
+        src_key_padding_mask = torch.cat([pad_mask, tgt_mask], dim=1)  # [B, T+1]
+
+        out = self.transformer_layers(seq, src_key_padding_mask=src_key_padding_mask)
+        # take target position output as interest representation
+        interest = out[:, -1, :]  # [B, item_dim]
+
+        mlp_in = torch.cat([
+            interest,
+            embed_x_target.flatten(start_dim=1),
+            embed_x_features.flatten(start_dim=1),
+        ], dim=1)
         y = self.mlp(mlp_in)
         return torch.sigmoid(y.squeeze(1))


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

Update README (EN/ZH) to require PyTorch 1.10+. Refactor BST model: add max_seq_len parameter and positional embeddings; compute fused item_dim from history features and validate it matches target_dim and is divisible by nhead. Change Transformer d_model to item_dim, use LeakyReLU activation, and build a TransformerEncoder with the new pos embedding. Fuse history features per timestep, append the target as the final token, construct a padding mask aggregated across history features, and use the transformer output at the target position as the interest representation. Adjust MLP input to include interest, flattened target embeddings, and other features; add sequence length checks and clearer validation errors.

## Type of Change / 变更类型

- [x] 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [ ] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护

