### PR TITLE
Adjust embedding outputs and unwrap ONNX scalar

### DIFF
--- a/torch_rechub/models/ranking/bst.py
+++ b/torch_rechub/models/ranking/bst.py
@@ -49,10 +49,11 @@ class BST(nn.Module):
         self.mlp = MLP(self.all_dims, **mlp_params)
 
     def forward(self, x):
-        embed_x_features = self.embedding(x, self.features)
-        # (batch_size, num_history_features, seq_length, emb_dim)
+        # [B, context_dim], with dense values and sparse embeddings flattened.
+        embed_x_features = self.embedding(x, self.features, squeeze_dim=True)
+        # [B, H, T, D]: H history feature fields, T sequence length.
         embed_x_history = self.embedding(x, self.history_features)
-        # (batch_size, num_target_features, emb_dim)
+        # [B, K, D]: K target feature fields.
         embed_x_target = self.embedding(x, self.target_features)
 
         # fuse all history features into one item vector per timestep: [B, T, item_dim]
@@ -64,7 +65,7 @@ class BST(nn.Module):
         seq = torch.cat([hist, tgt.unsqueeze(1)], dim=1)
         if seq.size(1) > self.max_seq_len:
             raise ValueError(f"sequence length {seq.size(1)} exceeds max_seq_len {self.max_seq_len}")
-        positions = torch.arange(seq.size(1), device=seq.device).unsqueeze(0)
+        positions = torch.arange(seq.size(1), device=seq.device).unsqueeze(0)  # [1, T+1]
         seq = seq + self.pos_embedding(positions)
 
         # padding mask: a position is padding only if ALL history features are padding there
@@ -75,14 +76,14 @@ class BST(nn.Module):
         tgt_mask = torch.zeros(pad_mask.size(0), 1, dtype=torch.bool, device=pad_mask.device)
         src_key_padding_mask = torch.cat([pad_mask, tgt_mask], dim=1)  # [B, T+1]
 
-        out = self.transformer_layers(seq, src_key_padding_mask=src_key_padding_mask)
+        out = self.transformer_layers(seq, src_key_padding_mask=src_key_padding_mask)  # [B, T+1, item_dim]
         # take target position output as interest representation
         interest = out[:, -1, :]  # [B, item_dim]
 
         mlp_in = torch.cat([
             interest,
             embed_x_target.flatten(start_dim=1),
-            embed_x_features.flatten(start_dim=1),
+            embed_x_features,
         ],
                            dim=1)
         y = self.mlp(mlp_in)

--- a/torch_rechub/models/ranking/dien.py
+++ b/torch_rechub/models/ranking/dien.py
@@ -29,7 +29,7 @@ class AUGRU_Cell(nn.Module):
         self.bh = init.xavier_uniform_(Parameter(torch.empty(1, embed_dim)))
 
     def forward(self, x, h_1, a):
-        # a: [ batch_size, 1 ] — pre-computed attention score for this step
+        # x, h_1: [B, D]; a: [B, 1], pre-computed attention score for this step.
         u = torch.sigmoid(torch.matmul(x, self.Wu) + torch.matmul(h_1, self.Uu) + self.bu)
         r = torch.sigmoid(torch.matmul(x, self.Wr) + torch.matmul(h_1, self.Ur) + self.br)
         h_hat = torch.tanh(torch.matmul(x, self.Wh) + r * torch.matmul(h_1, self.Uh) + self.bh)
@@ -126,15 +126,19 @@ class DIEN(nn.Module):
         return (self.BCELoss(pos_score, torch.ones_like(pos_score)) + self.BCELoss(neg_score, torch.zeros_like(neg_score)))
 
     def forward(self, x):
-        embed_x_features = self.embedding(x, self.features)
+        # [B, context_dim], with dense values and sparse embeddings flattened.
+        embed_x_features = self.embedding(x, self.features, squeeze_dim=True)
+        # [B, H, T, D]: H history feature fields, T sequence length.
         embed_x_history = self.embedding(x, self.history_features)
+        # [B, H, T, D]: negative sequence embeddings for the auxiliary loss.
         embed_x_neg_history = self.embedding(x, self.neg_history_features)
+        # [B, H, D]: target item embeddings aligned with history fields.
         embed_x_target = self.embedding(x, self.target_features)
 
         interest_extractor = []
         auxi_loss = 0
         for i, fea in enumerate(self.history_features):
-            seq = embed_x_history[:, i, :, :]
+            seq = embed_x_history[:, i, :, :]  # [B, T, D]
             mask = self.embedding.input_mask(x, fea).squeeze(1).bool()  # [B, T]
             seq_lens = mask.sum(dim=1).cpu()
 
@@ -147,9 +151,9 @@ class DIEN(nn.Module):
                 outs[has_hist] = unpacked
 
             auxi_loss += self.auxiliary(outs, seq, embed_x_neg_history[:, i, :, :], mask)
-            interest_extractor.append(outs.unsqueeze(1))
+            interest_extractor.append(outs.unsqueeze(1))  # [B, 1, T, D]
 
-        interest_extractor = torch.cat(interest_extractor, dim=1)
+        interest_extractor = torch.cat(interest_extractor, dim=1)  # [B, H, T, D]
 
         interest_evolving = []
         for i, fea in enumerate(self.history_features):
@@ -159,13 +163,13 @@ class DIEN(nn.Module):
             if has_hist.any():
                 _, h_valid = self.interest_evolving_layers[i](interest_extractor[has_hist, i, :, :], embed_x_target[has_hist, i, :], mask[has_hist])
                 h[has_hist] = h_valid
-            interest_evolving.append(h.unsqueeze(1))
+            interest_evolving.append(h.unsqueeze(1))  # [B, 1, D]
 
-        interest_evolving = torch.cat(interest_evolving, dim=1)
+        interest_evolving = torch.cat(interest_evolving, dim=1)  # [B, H, D]
         mlp_in = torch.cat([
             interest_evolving.flatten(start_dim=1),
             embed_x_target.flatten(start_dim=1),
-            embed_x_features.flatten(start_dim=1),
+            embed_x_features,
         ],
                            dim=1)
         y = self.mlp(mlp_in)

--- a/torch_rechub/utils/model_utils.py
+++ b/torch_rechub/utils/model_utils.py
@@ -62,6 +62,7 @@ def extract_feature_info(model: nn.Module) -> Dict[str, Any]:
         'user_features',      # DSSM, YoutubeDNN, MIND
         'item_features',      # DSSM, YoutubeDNN, MIND
         'history_features',   # DIN, MIND
+        'neg_history_features',  # DIEN auxiliary loss
         'target_features',    # DIN
         'neg_item_feature',   # YoutubeDNN, MIND
     ]

--- a/torch_rechub/utils/onnx_export.py
+++ b/torch_rechub/utils/onnx_export.py
@@ -60,7 +60,10 @@ class ONNXWrapper(nn.Module):
             raise ValueError(f"Expected {len(self.input_names)} inputs, got {len(args)}. "
                              f"Expected names: {self.input_names}")
         x_dict = {name: arg for name, arg in zip(self.input_names, args)}
-        return self.model(x_dict)
+        output = self.model(x_dict)
+        if isinstance(output, tuple) and len(output) == 2 and torch.is_tensor(output[1]) and output[1].dim() == 0:
+            return output[0]
+        return output
 
     def restore_mode(self):
         """Restore the original mode of the model."""


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

Use squeezed embedding outputs and add shape comments for BST and DIEN so embedding(...) returns flattened [B, context_dim] where appropriate (pass squeeze_dim=True) and avoid redundant .flatten() calls when building MLP inputs. DIEN: also embed negative history features and document tensor shapes through the interest extraction/evolving logic. Add 'neg_history_features' to extract_feature_info. Update ONNX wrapper to unwrap models that return (output, scalar_loss) by returning only the primary output, preventing a 0-dim tensor from being emitted.

## Type of Change / 变更类型

- [x] 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [ ] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护

## Checklist / 检查清单

- [x] Code follows project style (ran `python config/format_code.py`) / 代码遵循项目风格（运行了格式化脚本）
