### PR TITLE
Fix stray 'uv' in pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ PyTorch builds are tightly coupled with your hardware, driver, and runtime versi
 pip install torch                                                     # CPU
 pip install torch --index-url https://download.pytorch.org/whl/cu121  # NVIDIA GPU (CUDA 12.1)
 pip install torch torch-npu                                           # Huawei Ascend NPU (requires torch-npu >= 2.5.1)
-uv pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
+pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
 
 pip install torch-rechub
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -83,7 +83,7 @@ PyTorch 与硬件、驱动和运行时版本强相关。安装前建议先查看
 pip install torch                                                     # CPU
 pip install torch --index-url https://download.pytorch.org/whl/cu121  # NVIDIA GPU (CUDA 12.1)
 pip install torch torch-npu                                           # Huawei Ascend NPU (需要 torch-npu >= 2.5.1)
-uv pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
+pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
 
 pip install torch-rechub
 ```

--- a/docs/en/guide/install.md
+++ b/docs/en/guide/install.md
@@ -31,7 +31,7 @@ The simplest way to install is via pip:
 pip install torch                                                     # CPU
 pip install torch --index-url https://download.pytorch.org/whl/cu121  # NVIDIA GPU (CUDA 12.1)
 pip install torch torch-npu                                           # Huawei Ascend NPU (requires torch-npu >= 2.5.1)
-uv pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
+pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
 
 pip install torch-rechub
 ```

--- a/docs/zh/guide/install.md
+++ b/docs/zh/guide/install.md
@@ -31,7 +31,7 @@ PyTorch 与硬件、驱动和运行时版本强相关。安装前建议先查看
 pip install torch                                                     # CPU
 pip install torch --index-url https://download.pytorch.org/whl/cu121  # NVIDIA GPU (CUDA 12.1)
 pip install torch torch-npu                                           # Huawei Ascend NPU (需要 torch-npu >= 2.5.1)
-uv pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
+pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "rocm[libraries,devel]" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)
 
 pip install torch-rechub
 ```

--- a/tutorials/00_QuickStart_CTR_DeepFM.ipynb
+++ b/tutorials/00_QuickStart_CTR_DeepFM.ipynb
@@ -78,7 +78,7 @@
     "pip install torch                                                     # CPU\n",
     "pip install torch --index-url https://download.pytorch.org/whl/cu121  # NVIDIA GPU (CUDA 12.1)\n",
     "pip install torch torch-npu                                           # Huawei Ascend NPU (需要 torch-npu >= 2.5.1)\n",
-    "uv pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \"rocm[libraries,devel]\" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)\n",
+    "pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \"rocm[libraries,devel]\" torch torchvision torchaudio  # AMD GPU (ROCm, gfx1151 = Ryzen AI Max+ 395/390/385)\n",
     "\n",
     "pip install torch-rechub\n",
     "pip install notebook ipykernel scikit-learn tqdm\n",


### PR DESCRIPTION
# Pull Request / 拉取请求

## What does this PR do? / 这个PR做了什么？

Remove an accidental 'uv' prefix from the AMD/ROCm pip install line in README.md, README_zh.md, docs/en/guide/install.md, docs/zh/guide/install.md, and the tutorials notebook so the installation instructions are correct and consistent. Also normalize the notebook EOF newline.

## Type of Change / 变更类型

- [ ] 🐛 Bug fix / Bug修复
- [ ] ✨ New model/feature / 新模型/功能
- [x] 📝 Documentation / 文档
- [ ] 🔧 Maintenance / 维护
