### PR TITLE
feat(mind): dynamic per-user interest count (issue #240)

### DIFF
--- a/tests/test_mind_dynamic_interest.py
+++ b/tests/test_mind_dynamic_interest.py
@@ -1,0 +1,96 @@
+"""MIND dynamic interest count (issue #240).
+
+The MIND paper (Li et al., 2019, https://arxiv.org/abs/1904.08030) sizes the
+number of interest capsules per user by their history length::
+
+    K'_u = max(1, min(K, floor(log2(|I_u|))))
+
+i.e. a user with few interacted items gets fewer interest vectors. The default
+``CapsuleNetwork`` instead emits a fixed ``interest_num`` capsules for everyone.
+``dynamic_interest=True`` opts into the paper's per-user heuristic while leaving
+the default (fixed) behaviour byte-identical.
+"""
+
+import math
+
+import torch
+
+from torch_rechub.basic.features import SequenceFeature, SparseFeature
+from torch_rechub.basic.layers import CapsuleNetwork
+from torch_rechub.models.matching import MIND
+
+
+def _expected_k(hist_len, interest_num):
+    return max(1, min(interest_num, int(math.floor(math.log2(max(hist_len, 1))))))
+
+
+def _active_capsule_counts(interest_capsule, eps=1e-6):
+    # An interest capsule is "active" when it carries a non-zero vector.
+    return (interest_capsule.norm(dim=-1) > eps).sum(dim=1)
+
+
+def test_capsule_dynamic_interest_scales_with_history_length():
+    torch.manual_seed(0)
+    seq_len, dim, interest_num = 16, 8, 4
+    hist_lens = [1, 3, 8, 16]  # -> K'_u = [1, 1, 3, 4]
+
+    capsule = CapsuleNetwork(dim, seq_len, bilinear_type=0, interest_num=interest_num, dynamic_interest=True)
+    item_eb = torch.randn(len(hist_lens), seq_len, dim)
+    mask = torch.zeros(len(hist_lens), seq_len, dtype=torch.long)
+    for row, length in enumerate(hist_lens):
+        mask[row, :length] = 1
+
+    out = capsule(item_eb, mask)
+    assert out.shape == (len(hist_lens), interest_num, dim)
+
+    counts = _active_capsule_counts(out).tolist()
+    expected = [_expected_k(length, interest_num) for length in hist_lens]
+    assert counts == expected, f"active interests {counts} != paper K'_u {expected}"
+
+
+def test_capsule_fixed_interest_is_default_and_unchanged():
+    # Without the flag, every user keeps all ``interest_num`` capsules, even a
+    # single-item history — the pre-#240 behaviour.
+    torch.manual_seed(0)
+    seq_len, dim, interest_num = 16, 8, 4
+
+    capsule = CapsuleNetwork(dim, seq_len, bilinear_type=0, interest_num=interest_num)
+    item_eb = torch.randn(2, seq_len, dim)
+    mask = torch.zeros(2, seq_len, dtype=torch.long)
+    mask[0, :1] = 1  # one-item user
+    mask[1, :] = 1  # full-history user
+
+    out = capsule(item_eb, mask)
+    counts = _active_capsule_counts(out).tolist()
+    assert counts == [interest_num, interest_num]
+
+
+def _build_mind(max_length, interest_num, dynamic_interest):
+    n_items = 50
+    user_features = [SparseFeature("user_id", vocab_size=20, embed_dim=16)]
+    history_features = [SequenceFeature("hist_movie_id", vocab_size=n_items, embed_dim=16, pooling="concat", shared_with="movie_id")]
+    item_features = [SparseFeature("movie_id", vocab_size=n_items, embed_dim=16)]
+    neg_item_feature = [SequenceFeature("neg_items", vocab_size=n_items, embed_dim=16, pooling="concat", shared_with="movie_id")]
+    return MIND(user_features, history_features, item_features, neg_item_feature, max_length=max_length, interest_num=interest_num, dynamic_interest=dynamic_interest)
+
+
+def test_mind_user_tower_emits_dynamic_interests():
+    # End-to-end through MIND's user tower: the user embedding exposes exactly
+    # K'_u non-zero interest vectors per user.
+    torch.manual_seed(0)
+    max_length, interest_num = 16, 4
+    hist_lens = [1, 8, 16]  # -> K'_u = [1, 3, 4]
+
+    model = _build_mind(max_length, interest_num, dynamic_interest=True)
+    model.mode = "user"
+    hist = torch.zeros(len(hist_lens), max_length, dtype=torch.long)
+    for row, length in enumerate(hist_lens):
+        hist[row, :length] = torch.arange(1, length + 1)
+    x = {"user_id": torch.arange(len(hist_lens)), "hist_movie_id": hist}
+
+    user_emb = model.user_tower(x)
+    assert user_emb.shape == (len(hist_lens), interest_num, user_emb.shape[-1])
+
+    counts = _active_capsule_counts(user_emb).tolist()
+    expected = [_expected_k(length, interest_num) for length in hist_lens]
+    assert counts == expected, f"user-tower interests {counts} != paper K'_u {expected}"

--- a/torch_rechub/basic/layers.py
+++ b/torch_rechub/basic/layers.py
@@ -609,6 +609,27 @@ class MultiInterestSA(nn.Module):
         return multi_interest_emb
 
 
+def dynamic_interest_mask(mask, interest_num):
+    """Per-user active-interest mask following the MIND paper's heuristic.
+
+    Sizes the number of interests by history length
+    ``K'_u = max(1, min(interest_num, floor(log2(|I_u|))))`` where ``|I_u|`` is
+    each user's interacted-item count (``mask.sum(-1)``).
+
+    Args:
+        mask (Tensor): history mask ``(B, L)`` with 1 for real items, 0 for padding.
+        interest_num (int): upper bound ``K`` on the number of interests.
+
+    Returns:
+        Tensor: boolean ``(B, interest_num)`` mask, ``True`` for the first
+        ``K'_u`` (active) interests of each user.
+    """
+    hist_len = mask.sum(dim=1).float().clamp(min=1.0)  # |I_u|, >=1 to keep log2 finite
+    k_u = torch.floor(torch.log2(hist_len)).clamp(min=1, max=interest_num)  # (B,)
+    idx = torch.arange(interest_num, device=mask.device).view(1, -1)  # (1, K)
+    return idx < k_u.unsqueeze(1)  # (B, K)
+
+
 class CapsuleNetwork(nn.Module):
     """Capsule network for multi-interest (MIND/Comirec).
 
@@ -621,11 +642,16 @@ class CapsuleNetwork(nn.Module):
     bilinear_type : {0, 1, 2}, default 2
         0 for MIND, 2 for ComirecDR.
     interest_num : int, default 4
-        Number of interests.
+        Number of interests (the upper bound ``K`` when ``dynamic_interest``).
     routing_times : int, default 3
         Routing iterations.
     relu_layer : bool, default False
         Whether to apply ReLU after routing.
+    dynamic_interest : bool, default False
+        If ``True``, size the active interests per user by the MIND paper's
+        heuristic ``K'_u = max(1, min(interest_num, floor(log2(|I_u|))))``
+        (|I_u| = history length from ``mask``); surplus capsules are zeroed.
+        If ``False`` (default), every user gets the full ``interest_num``.
 
     Shape
     -----
@@ -636,13 +662,14 @@ class CapsuleNetwork(nn.Module):
         ``(B, interest_num, D)``
     """
 
-    def __init__(self, embedding_dim, seq_len, bilinear_type=2, interest_num=4, routing_times=3, relu_layer=False):
+    def __init__(self, embedding_dim, seq_len, bilinear_type=2, interest_num=4, routing_times=3, relu_layer=False, dynamic_interest=False):
         super(CapsuleNetwork, self).__init__()
         self.embedding_dim = embedding_dim  # h
         self.seq_len = seq_len  # s
         self.bilinear_type = bilinear_type
         self.interest_num = interest_num
         self.routing_times = routing_times
+        self.dynamic_interest = dynamic_interest
 
         self.relu_layer = relu_layer
         self.stop_grad = True
@@ -678,12 +705,19 @@ class CapsuleNetwork(nn.Module):
         else:
             capsule_weight = torch.randn(item_eb_hat.shape[0], self.interest_num, self.seq_len, device=item_eb.device, requires_grad=False)
 
+        # Per-user active-interest mask (paper's K'_u); None keeps the fixed-K behaviour.
+        interest_mask = dynamic_interest_mask(mask, self.interest_num).unsqueeze(-1).float() if self.dynamic_interest else None
+
         for i in range(self.routing_times):  # 动态路由传播3次
             atten_mask = torch.unsqueeze(mask, 1).repeat(1, self.interest_num, 1)
             paddings = torch.zeros_like(atten_mask, dtype=torch.float)
 
             capsule_softmax_weight = F.softmax(capsule_weight, dim=-1)
             capsule_softmax_weight = torch.where(torch.eq(atten_mask, 0), paddings, capsule_softmax_weight)
+            if interest_mask is not None:
+                # Zero the routing weight of surplus (inactive) capsules so they
+                # receive no item mass and collapse to zero interest vectors.
+                capsule_softmax_weight = capsule_softmax_weight * interest_mask
             capsule_softmax_weight = torch.unsqueeze(capsule_softmax_weight, 2)
 
             if i < 2:
@@ -704,6 +738,9 @@ class CapsuleNetwork(nn.Module):
                 interest_capsule = scalar_factor * interest_capsule
 
         interest_capsule = torch.reshape(interest_capsule, (-1, self.interest_num, self.embedding_dim))
+
+        if interest_mask is not None:
+            interest_capsule = interest_capsule * interest_mask
 
         if self.relu_layer:
             interest_capsule = self.relu(interest_capsule)

--- a/torch_rechub/models/matching/mind.py
+++ b/torch_rechub/models/matching/mind.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from ...basic.layers import MLP, CapsuleNetwork, EmbeddingLayer, MultiInterestSA
+from ...basic.layers import MLP, CapsuleNetwork, EmbeddingLayer, MultiInterestSA, dynamic_interest_mask
 
 
 class MIND(torch.nn.Module):
@@ -26,10 +26,13 @@ class MIND(torch.nn.Module):
         neg_item_feature (list[Feature Class]): training by the embedding table, it's the negative items id feature.
         max_length (int): max sequence length of input item sequence
         temperature (float): temperature factor for similarity score, default to 1.0.
-        interest_num （int): interest num
+        interest_num （int): interest num (the upper bound ``K`` when ``dynamic_interest``).
+        dynamic_interest (bool): if ``True``, size the active interests per user by the
+            paper's heuristic ``K'_u = max(1, min(interest_num, floor(log2(|I_u|))))``
+            instead of a fixed ``interest_num``. Defaults to ``False`` (unchanged behaviour).
     """
 
-    def __init__(self, user_features, history_features, item_features, neg_item_feature, max_length, temperature=1.0, interest_num=4):
+    def __init__(self, user_features, history_features, item_features, neg_item_feature, max_length, temperature=1.0, interest_num=4, dynamic_interest=False):
         super().__init__()
         self.user_features = user_features
         self.item_features = item_features
@@ -37,11 +40,12 @@ class MIND(torch.nn.Module):
         self.neg_item_feature = neg_item_feature
         self.temperature = temperature
         self.interest_num = interest_num
+        self.dynamic_interest = dynamic_interest
         self.max_length = max_length
         self.user_dims = sum([fea.embed_dim for fea in user_features + history_features])
 
         self.embedding = EmbeddingLayer(user_features + item_features + history_features)
-        self.capsule = CapsuleNetwork(self.history_features[0].embed_dim, self.max_length, bilinear_type=0, interest_num=self.interest_num)
+        self.capsule = CapsuleNetwork(self.history_features[0].embed_dim, self.max_length, bilinear_type=0, interest_num=self.interest_num, dynamic_interest=self.dynamic_interest)
         self.convert_user_weight = nn.Parameter(torch.rand(self.user_dims, self.history_features[0].embed_dim), requires_grad=True)
         self.mode = None
 
@@ -55,6 +59,10 @@ class MIND(torch.nn.Module):
 
         pos_item_embedding = item_embedding[:, 0, :]
         dot_res = torch.bmm(user_embedding, pos_item_embedding.squeeze(1).unsqueeze(-1))
+        if self.dynamic_interest:
+            # Never route the label-aware attention to a surplus (inactive) interest.
+            interest_mask = dynamic_interest_mask(self.gen_mask(x), self.interest_num)
+            dot_res = dot_res.masked_fill(~interest_mask.unsqueeze(-1), float("-inf"))
         k_index = torch.argmax(dot_res, dim=1).squeeze(-1)
         batch_index = torch.arange(user_embedding.shape[0], device=user_embedding.device)
         best_interest_emb = user_embedding[batch_index, k_index, :].unsqueeze(1)
@@ -78,6 +86,10 @@ class MIND(torch.nn.Module):
         # #[batch_size, interest_num, embed_dim]
         user_embedding = torch.matmul(input_user, self.convert_user_weight)
         user_embedding = F.normalize(user_embedding, p=2, dim=-1)  # L2 normalize
+        if self.dynamic_interest:
+            # Zero the surplus interests so downstream selection/retrieval sees only K'_u.
+            interest_mask = dynamic_interest_mask(mask, self.interest_num)
+            user_embedding = user_embedding * interest_mask.unsqueeze(-1)
         if self.mode == "user":
             # inference embedding mode -> [batch_size, interest_num, embed_dim]
             return user_embedding


### PR DESCRIPTION
## What

Closes #240. The MIND paper (Li et al., 2019) sizes each user's number of
interest vectors by their history length:

    K'_u = max(1, min(interest_num, floor(log2(|I_u|))))

so a user with few interactions gets fewer interests. The current
`CapsuleNetwork` instead emits a fixed `interest_num` capsules for everyone —
which the maintainer confirmed in the issue thread.

## Change

Add a `dynamic_interest` flag (default `False`, so existing behaviour is
byte-identical) to `MIND` and `CapsuleNetwork`:

- `dynamic_interest_mask()` computes the per-user active-interest count from
  the history mask.
- In `CapsuleNetwork`'s dynamic routing, surplus (inactive) capsules receive
  zero routing weight, so they get no item mass and collapse to zero vectors.
- `MIND` masks the inactive interests out of both the label-aware selection
  (training) and the user-tower inference embedding, so downstream
  selection/retrieval only ever sees `K'_u` interests.

## Tests

New `tests/test_mind_dynamic_interest.py`:
- `CapsuleNetwork` with histories `[1, 3, 8, 16]` yields exactly `[1, 1, 3, 4]`
  active interests (the paper's K'_u).
- backward-compat guard: without the flag every user keeps all `interest_num`
  capsules (incl. a single-item history) — the pre-#240 behaviour.
- end-to-end through `MIND`'s user tower: `[1, 8, 16]` → `[1, 3, 4]` non-zero
  interest vectors.

Full suite green (50 passed, 0 failed); code run through `config/format_code.py`
(isort + yapf).
