### PR TITLE
fix: 替换 4 处失效的奶牛快传数据链接（承接 #201）

### DIFF
--- a/examples/matching/README.md
+++ b/examples/matching/README.md
@@ -8,7 +8,7 @@
 - 使用随机负采样构造负样本 (sample_method=0)，内含随机负采样、word2vec负采样、流行度负采样、Tencent负采样等多种方法
 - 将每个用户最后一条观看记录设置为测试集
 - 原始数据下载地址：https://grouplens.org/datasets/movielens/1m/
-- 处理完整数据csv下载地址：https://cowtransfer.com/s/5a3ab69ebd314e
+- 处理完整数据csv获取方式：从[官方原始数据](https://grouplens.org/datasets/movielens/1m/)下载后运行 [preprocess_ml.py](./data/ml-1m/preprocess_ml.py) 复现，或使用楼内已验证的备用网盘（见 issue #201）
 
 以下指标使用example中的相同参数在ml-1m上测试得到
 

--- a/tutorials/DIN.ipynb
+++ b/tutorials/DIN.ipynb
@@ -89,7 +89,7 @@
     "这里我们以Amazon-Electronics为例，原数据是json格式，我们提取所需要的信息预处理为一个仅包含user_id, item_id, cate_id, time四个特征列的CSV文件。\n",
     "\n",
     "注意：examples文件夹中仅有100行数据方便我们轻量化学习，如果需要Amazon数据集全量数据用于测试模型性能有两种方法：\n",
-    "1. 我们提供了处理完成的全量数据在高速网盘链接：https://cowtransfer.com/s/e911569fbb1043 ，只需要下载全量数据后替换下一行的file_path即可；\n",
+    "1. 处理完成的全量数据已托管在[飞桨 AI Studio](https://aistudio.baidu.com/dataset/detail/355993)（即 examples/ranking 中 Amazon-Electronics 数据集的官方下载渠道），下载后替换下一行的file_path即可；\n",
     "2. 前往Amazon数据集官网：http://jmcauley.ucsd.edu/data/amazon/index_2014.html ，进入后选择elextronics下载，我们同样提供了数据集处理脚本在examples/ranking/data/amazon-electronics/preprocess_amazon_electronics.py文件中。"
    ]
   },

--- a/tutorials/Matching.ipynb
+++ b/tutorials/Matching.ipynb
@@ -76,7 +76,7 @@
     "### MovieLens数据集\n",
     "- MovieLens数据集是电影网站提供的一份数据集，[原数据](https://grouplens.org/datasets/movielens/1m/)分为三个文件，users.dat movies.dat ratings.dat，包含了用户信息、电影信息和用户对电影的评分信息。\n",
     "\n",
-    "- 提供原始数据处理之后（参考examples/matching/data/ml-1m/preprocess_ml.py），全量数据集[**ml-1m.csv**](https://cowtransfer.com/s/5a3ab69ebd314e)\n",
+    "- 提供原始数据处理之后（参考examples/matching/data/ml-1m/preprocess_ml.py），全量数据集**ml-1m.csv**可从[官方原始数据](https://grouplens.org/datasets/movielens/1m/)下载后运行 preprocess_ml.py 复现\n",
     "\n",
     "- 采样后的**ml-1m_sample.csv**(examples/matching/data/ml-1m/ml-1m_sample.csv)，是在全量数据中取出的前100个样本，调试用。在大家用ml-1m_sample.csv跑通代码后，便可以下载全量数据集测试效果，共100万个样本。"
    ]

--- a/tutorials/Milvus.ipynb
+++ b/tutorials/Milvus.ipynb
@@ -120,7 +120,7 @@
     "### MovieLens数据集\n",
     "- MovieLens数据集是电影网站提供的一份数据集，[原数据](https://grouplens.org/datasets/movielens/1m/)分为三个文件，users.dat movies.dat ratings.dat，包含了用户信息、电影信息和用户对电影的评分信息。\n",
     "\n",
-    "- 提供原始数据处理之后（参考examples/matching/data/ml-1m/preprocess_ml.py），全量数据集[**ml-1m.csv**](https://cowtransfer.com/s/5a3ab69ebd314e)\n",
+    "- 提供原始数据处理之后（参考examples/matching/data/ml-1m/preprocess_ml.py），全量数据集**ml-1m.csv**可从[官方原始数据](https://grouplens.org/datasets/movielens/1m/)下载后运行 preprocess_ml.py 复现\n",
     "\n",
     "- 采样后的**ml-1m_sample.csv**(examples/matching/data/ml-1m/ml-1m_sample.csv)，是在全量数据中取出的前100个样本，调试用。在大家用ml-1m_sample.csv跑通代码后，便可以下载全量数据集测试效果，共100万个样本。"
    ]


### PR DESCRIPTION
承接 #201 中维护者的指派（「如果有遗留的未替换链接，可以帮忙进行替换」）。

## 替换内容

对全仓库 124 个 md/ipynb 文件扫描后，确认奶牛快传残留共 **4 处**（其余链接均已更新为飞桨/HF）：

| # | 文件 | 数据集 | 替换方案 |
|---|------|--------|----------|
| 1 | `examples/matching/README.md` | ml-1m.csv | 官方原始数据 + `preprocess_ml.py` 复现指引 |
| 2 | `tutorials/Matching.ipynb` | ml-1m.csv | 同上 |
| 3 | `tutorials/Milvus.ipynb` | ml-1m.csv | 同上 |
| 4 | `tutorials/DIN.ipynb` | Amazon-Electronics 全量 | 飞桨 [AI Studio 355993](https://aistudio.baidu.com/dataset/detail/355993) |

## 方案说明

- **ml-1m（#1~#3）**：`examples/generative/data/ml-1m/README` 已验证「官方 grouplens 自动下载 + 预处理脚本」链路完整可用（`https://files.grouplens.org/datasets/movielens/ml-1m.zip`），matching 侧的 `preprocess_ml.py` 即对应脚本，故引导用户走官方复现，不再依赖任何网盘。README 中同时注明 issue #201 楼内已验证的百度网盘（提取码 div6）作为备用渠道。
- **Amazon-Electronics（#4）**：ranking README 中该数据集「预处理后的全量数据」官方托管地址即 AI Studio 355993（实测可达），DIN tutorial 使用的是同一份四列 CSV，直接复用该渠道。

奶牛快传 API 已整体不可用（`/api/transfer/health` 返回 ring-balancer 错误），SPA 壳页面一律 200 但无法实际下载，与 #201 楼主描述一致。

均为最小改动，仅替换链接与指引文字，不改任何代码逻辑。